### PR TITLE
Propose new pdf integration testing strategy

### DIFF
--- a/src/main/java/org/codeforamerica/shiba/output/DerivedValueConfiguration.java
+++ b/src/main/java/org/codeforamerica/shiba/output/DerivedValueConfiguration.java
@@ -3,7 +3,8 @@ package org.codeforamerica.shiba.output;
 import org.codeforamerica.shiba.pages.data.ApplicationData;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface DerivedValueConfiguration {
-    List<String> resolve(ApplicationData data);
+    Optional<List<String>> resolveOptional(ApplicationData data);
 }

--- a/src/main/java/org/codeforamerica/shiba/output/LiteralDerivedValueConfiguration.java
+++ b/src/main/java/org/codeforamerica/shiba/output/LiteralDerivedValueConfiguration.java
@@ -4,13 +4,14 @@ import lombok.Data;
 import org.codeforamerica.shiba.pages.data.ApplicationData;
 
 import java.util.List;
+import java.util.Optional;
 
 @Data
 public class LiteralDerivedValueConfiguration implements DerivedValueConfiguration {
     private String literal;
 
     @Override
-    public List<String> resolve(ApplicationData data) {
-        return List.of(literal);
+    public Optional<List<String>> resolveOptional(ApplicationData data) {
+        return Optional.of(List.of(literal));
     }
 }

--- a/src/main/java/org/codeforamerica/shiba/output/ReferenceDerivedValueConfiguration.java
+++ b/src/main/java/org/codeforamerica/shiba/output/ReferenceDerivedValueConfiguration.java
@@ -2,8 +2,10 @@ package org.codeforamerica.shiba.output;
 
 import lombok.Data;
 import org.codeforamerica.shiba.pages.data.ApplicationData;
+import org.codeforamerica.shiba.pages.data.InputData;
 
 import java.util.List;
+import java.util.Optional;
 
 @Data
 public class ReferenceDerivedValueConfiguration implements DerivedValueConfiguration {
@@ -11,9 +13,9 @@ public class ReferenceDerivedValueConfiguration implements DerivedValueConfigura
     private String inputName;
 
     @Override
-    public List<String> resolve(ApplicationData data) {
-        return data.getInputDataMap(pageName)
-                .get(inputName)
-                .getValue();
+    public Optional<List<String>> resolveOptional(ApplicationData data) {
+        return Optional.ofNullable(data.getInputDataMap(pageName))
+                .flatMap(pageData -> Optional.ofNullable(pageData.get(inputName)))
+                .map(InputData::getValue);
     }
 }

--- a/src/main/java/org/codeforamerica/shiba/output/applicationinputsmappers/DerivedValueApplicationInputsMapper.java
+++ b/src/main/java/org/codeforamerica/shiba/output/applicationinputsmappers/DerivedValueApplicationInputsMapper.java
@@ -28,13 +28,15 @@ public class DerivedValueApplicationInputsMapper implements ApplicationInputsMap
                         .stream()
                         .filter(derivedValue -> derivedValue.shouldDeriveValue(data))
                         .findFirst()
-                        .map(derivedValue -> new ApplicationInput(
-                                potentialDerivedValues.getGroupName(),
-                                potentialDerivedValues.getFieldName(),
-                                derivedValue.getValue().resolve(data),
-                                derivedValue.getType(),
-                                potentialDerivedValues.getIteration()
-                        ))
+                        .flatMap(derivedValue -> derivedValue.getValue().resolveOptional(data)
+                                .map(value -> new ApplicationInput(
+                                        potentialDerivedValues.getGroupName(),
+                                        potentialDerivedValues.getFieldName(),
+                                        value,
+                                        derivedValue.getType(),
+                                        potentialDerivedValues.getIteration()
+                                ))
+                        )
                 )
                 .flatMap(Optional::stream)
                 .collect(Collectors.toList());

--- a/src/main/java/org/codeforamerica/shiba/output/caf/FileNameGenerator.java
+++ b/src/main/java/org/codeforamerica/shiba/output/caf/FileNameGenerator.java
@@ -27,7 +27,7 @@ public class FileNameGenerator {
     }
 
     public String generateFileName(Application application) {
-        List<String> programsList = application.getApplicationData().getPagesData().getPage("choosePrograms").get("programs").getValue();
+        List<String> programsList = application.getApplicationData().getPagesData().safeGetPageInputValue("choosePrograms", "programs");
         final StringBuilder programs = new StringBuilder();
         List.of("E", "K", "F", "C").forEach(letter -> {
                     if (programsList.stream()

--- a/src/main/java/org/codeforamerica/shiba/output/caf/HomeAddressStreetMapper.java
+++ b/src/main/java/org/codeforamerica/shiba/output/caf/HomeAddressStreetMapper.java
@@ -15,6 +15,9 @@ public class HomeAddressStreetMapper implements ApplicationInputsMapper {
     @Override
     public List<ApplicationInput> map(Application application, Recipient recipient) {
         PageData homeAddressPageData = application.getApplicationData().getPagesData().getPage("homeAddress");
+        if (homeAddressPageData == null) {
+            return List.of();
+        }
         if (String.join("", homeAddressPageData.get("streetAddress").getValue()).isBlank()) {
             return List.of(new ApplicationInput(
                     "homeAddress",

--- a/src/test/java/org/codeforamerica/shiba/AbstractBasePageTest.java
+++ b/src/test/java/org/codeforamerica/shiba/AbstractBasePageTest.java
@@ -1,6 +1,7 @@
-package org.codeforamerica.shiba.pages;
+package org.codeforamerica.shiba;
 
 import io.github.bonigarcia.wdm.WebDriverManager;
+import org.codeforamerica.shiba.pages.Page;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -27,7 +28,7 @@ import static org.springframework.boot.test.context.SpringBootTest.WebEnvironmen
 @SpringBootTest(webEnvironment = RANDOM_PORT, properties = {"spring.main.allow-bean-definition-overriding=true"})
 @ActiveProfiles("test")
 @ExtendWith(SpringExtension.class)
-abstract class AbstractBasePageTest {
+public abstract class AbstractBasePageTest {
     static protected RemoteWebDriver driver;
 
     protected Path path;
@@ -45,7 +46,7 @@ abstract class AbstractBasePageTest {
     }
 
     @BeforeEach
-    void setUp() throws IOException {
+    protected void setUp() throws IOException {
         baseUrl = String.format("http://localhost:%s", localServerPort);
         ChromeOptions options = new ChromeOptions();
         path = Files.createTempDirectory("");
@@ -62,7 +63,7 @@ abstract class AbstractBasePageTest {
         driver.quit();
     }
 
-    void navigateTo(String pageName) {
+    protected void navigateTo(String pageName) {
         driver.navigate().to(baseUrl + "/pages/" + pageName);
     }
 

--- a/src/test/java/org/codeforamerica/shiba/AbstractExistingStartTimePageTest.java
+++ b/src/test/java/org/codeforamerica/shiba/AbstractExistingStartTimePageTest.java
@@ -1,4 +1,4 @@
-package org.codeforamerica.shiba.pages;
+package org.codeforamerica.shiba;
 
 import org.codeforamerica.shiba.pages.data.ApplicationData;
 import org.junit.jupiter.api.BeforeEach;
@@ -14,7 +14,7 @@ public class AbstractExistingStartTimePageTest extends AbstractStaticMessageSour
 
     @Override
     @BeforeEach
-    void setUp() throws IOException {
+    protected void setUp() throws IOException {
         super.setUp();
         driver.navigate().to(baseUrl + "/setStartTimeForTest");
     }

--- a/src/test/java/org/codeforamerica/shiba/AbstractStaticMessageSourcePageTest.java
+++ b/src/test/java/org/codeforamerica/shiba/AbstractStaticMessageSourcePageTest.java
@@ -1,4 +1,4 @@
-package org.codeforamerica.shiba.pages;
+package org.codeforamerica.shiba;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,7 +18,7 @@ public class AbstractStaticMessageSourcePageTest extends AbstractBasePageTest {
 
     @Override
     @BeforeEach
-    void setUp() throws IOException {
+    protected void setUp() throws IOException {
         super.setUp();
         staticMessageSource = (StaticMessageSource) messageSource;
         staticMessageSource.addMessage("general.go-back", Locale.US, "Go Back");

--- a/src/test/java/org/codeforamerica/shiba/StaticMessageSourceConfiguration.java
+++ b/src/test/java/org/codeforamerica/shiba/StaticMessageSourceConfiguration.java
@@ -1,4 +1,4 @@
-package org.codeforamerica.shiba.pages;
+package org.codeforamerica.shiba;
 
 import org.springframework.context.MessageSource;
 import org.springframework.context.annotation.Bean;

--- a/src/test/java/org/codeforamerica/shiba/output/DerivedValueApplicationInputsMapperTest.java
+++ b/src/test/java/org/codeforamerica/shiba/output/DerivedValueApplicationInputsMapperTest.java
@@ -19,6 +19,7 @@ import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
 
+import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest(properties = {"spring.main.allow-bean-definition-overriding=true"})
@@ -99,6 +100,17 @@ class DerivedValueApplicationInputsMapperTest {
         List<ApplicationInput> actual = derivedValueApplicationInputsMapper.map(application, Recipient.CLIENT);
 
         assertThat(actual).contains(new ApplicationInput("groupName5", "value5", List.of("defaultValue"), ApplicationInputType.SINGLE_VALUE));
+    }
+
+    @Test
+    void shouldSkipReferencedValuesThatCannotBeResolved() {
+        pagesData.remove("defaultPage");
+
+        List<String> actual = derivedValueApplicationInputsMapper.map(application, Recipient.CLIENT).stream()
+                .map(ApplicationInput::getName)
+                .collect(toList());
+        
+        assertThat(actual).doesNotContain("value5");
     }
 
     @Test

--- a/src/test/java/org/codeforamerica/shiba/output/applicationinputsmappers/FileNameGeneratorTest.java
+++ b/src/test/java/org/codeforamerica/shiba/output/applicationinputsmappers/FileNameGeneratorTest.java
@@ -103,6 +103,16 @@ class FileNameGeneratorTest {
     }
 
     @Test
+    void omitsProgramCodes_ifNoProgramsAreChosen() {
+        ApplicationData applicationData = new ApplicationData();
+        Application application = defaultApplicationBuilder.applicationData(applicationData).build();
+
+        String fileName = fileNameGenerator.generateFileName(application);
+
+        assertThat(fileName).endsWith("defaultId_");
+    }
+
+    @Test
     void shouldArrangeNameCorrectly() {
         PageData chooseProgramsData = new PageData(Map.of("programs", InputData.builder().value(List.of("SNAP")).build()));
         ApplicationData applicationData = new ApplicationData();

--- a/src/test/java/org/codeforamerica/shiba/output/applicationinputsmappers/HomeAddressStreetMapperTest.java
+++ b/src/test/java/org/codeforamerica/shiba/output/applicationinputsmappers/HomeAddressStreetMapperTest.java
@@ -105,4 +105,13 @@ class HomeAddressStreetMapperTest {
                 List.of("No permanent address"),
                 ApplicationInputType.SINGLE_VALUE));
     }
+
+    @Test
+    void shouldNotIncludeApplicationInputs_whenThereIsNoHomeAddress() {
+        applicationData.setPagesData(new PagesData());
+
+        List<ApplicationInput> map = mapper.map(application, null);
+
+        assertThat(map).isEmpty();
+    }
 }

--- a/src/test/java/org/codeforamerica/shiba/output/pdf/PdfIntegrationTest.java
+++ b/src/test/java/org/codeforamerica/shiba/output/pdf/PdfIntegrationTest.java
@@ -1,485 +1,334 @@
 package org.codeforamerica.shiba.output.pdf;
 
-import org.codeforamerica.shiba.application.Application;
-import org.codeforamerica.shiba.application.ApplicationRepository;
-import org.codeforamerica.shiba.output.ApplicationInput;
-import org.codeforamerica.shiba.output.ApplicationInputType;
-import org.codeforamerica.shiba.output.applicationinputsmappers.ApplicationInputsMappers;
-import org.codeforamerica.shiba.output.caf.CoverPageInputsMapper;
-import org.codeforamerica.shiba.pages.data.*;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.interactive.form.PDAcroForm;
+import org.codeforamerica.shiba.AbstractBasePageTest;
+import org.codeforamerica.shiba.pages.SuccessPage;
+import org.codeforamerica.shiba.pages.enrichment.Address;
+import org.codeforamerica.shiba.pages.enrichment.LocationClient;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import java.time.ZonedDateTime;
-import java.util.List;
-import java.util.Map;
+import java.io.File;
+import java.io.IOException;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Arrays;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.codeforamerica.shiba.output.ApplicationInputType.ENUMERATED_SINGLE_VALUE;
-import static org.codeforamerica.shiba.output.Recipient.CASEWORKER;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 
-@SpringBootTest
-@ActiveProfiles("test")
-@ExtendWith(SpringExtension.class)
-public class PdfIntegrationTest {
-    @Autowired
-    private ApplicationInputsMappers mappers;
+public class PdfIntegrationTest extends AbstractBasePageTest {
+    @MockBean
+    Clock clock;
 
     @MockBean
-    CoverPageInputsMapper coverPageInputsMapper;
+    LocationClient locationClient;
 
-    @MockBean
-    private ApplicationRepository applicationRepository;
-
-    ApplicationData data = new ApplicationData();
-    PagesData pagesData = new PagesData();
-    private final ZonedDateTime completedAt = ZonedDateTime.now();
-    private final Application application = Application.builder()
-            .id("someId")
-            .completedAt(completedAt)
-            .applicationData(data)
-            .county(null)
-            .timeToComplete(null)
-            .build();
-    private final PageData homeAddressPageData = new PageData();
-    private final PageData mailingAddressPageData = new PageData();
-    private final PageData homeAddressValidationPageData = new PageData();
-    private final PageData mailingAddressValidationPageData = new PageData();
-
+    @Override
     @BeforeEach
-    void setUp() {
-        data.setPagesData(pagesData);
-
-        homeAddressPageData.put("zipCode", InputData.builder().value(List.of("")).build());
-        homeAddressPageData.put("enrichedZipCode", InputData.builder().value(List.of("")).build());
-        homeAddressPageData.put("city", InputData.builder().value(List.of("")).build());
-        homeAddressPageData.put("enrichedCity", InputData.builder().value(List.of("")).build());
-        homeAddressPageData.put("state", InputData.builder().value(List.of("")).build());
-        homeAddressPageData.put("streetAddress", InputData.builder().value(List.of("")).build());
-        homeAddressPageData.put("apartmentNumber", InputData.builder().value(List.of("")).build());
-        homeAddressPageData.put("isHomeless", InputData.builder().value(List.of("")).build());
-        homeAddressPageData.put("sameMailingAddress", InputData.builder().value(List.of("")).build());
-        homeAddressValidationPageData.put("useEnrichedAddress", InputData.builder().value(List.of("")).build());
-
-        mailingAddressPageData.put("zipCode", InputData.builder().value(List.of("")).build());
-        mailingAddressPageData.put("city", InputData.builder().value(List.of("")).build());
-        mailingAddressPageData.put("state", InputData.builder().value(List.of("")).build());
-        mailingAddressPageData.put("streetAddress", InputData.builder().value(List.of("")).build());
-        mailingAddressPageData.put("apartmentNumber", InputData.builder().value(List.of("")).build());
-        mailingAddressValidationPageData.put("useEnrichedAddress", InputData.builder().value(List.of("")).build());
-
-
-        pagesData.putPage("homeAddress", homeAddressPageData);
-        pagesData.putPage("homeAddressValidation", homeAddressValidationPageData);
-        pagesData.putPage("mailingAddress", mailingAddressPageData);
-        pagesData.putPage("mailingAddressValidation", mailingAddressValidationPageData);
+    protected void setUp() throws IOException {
+        super.setUp();
+        when(clock.instant()).thenReturn(Instant.now());
+        when(clock.getZone()).thenReturn(ZoneOffset.UTC);
+        when(locationClient.validateAddress(any())).thenReturn(Optional.empty());
+        driver.navigate().to(baseUrl);
+        testPage.clickButton("Apply now");
+        testPage.clickContinue();
+        testPage.clickContinue();
     }
 
     @Test
     void shouldMapNoForUnearnedIncomeOptionsThatAreNotChecked() {
-        PageData pageData = new PageData();
-        pageData.put(
-                "unearnedIncome",
-                InputData.builder()
-                        .value(List.of("SOCIAL_SECURITY", "CHILD_OR_SPOUSAL_SUPPORT"))
-                        .build()
-        );
-        pagesData.putPage("unearnedIncome", pageData);
-        data.setPagesData(pagesData);
+        navigateTo("unearnedIncome");
+        testPage.enter("unearnedIncome", "Social Security");
+        testPage.enter("unearnedIncome", "Child or Spousal support");
+        testPage.clickContinue();
 
-        List<ApplicationInput> applicationInputs = mappers.map(application, CASEWORKER);
-
-        assertThat(applicationInputs).contains(
-                new ApplicationInput("unearnedIncome", "unearnedIncome", List.of("SOCIAL_SECURITY", "CHILD_OR_SPOUSAL_SUPPORT"), ApplicationInputType.ENUMERATED_MULTI_VALUE),
-                new ApplicationInput("unearnedIncome", "noSSI", List.of("No"), ENUMERATED_SINGLE_VALUE),
-                new ApplicationInput("unearnedIncome", "noVeteransBenefits", List.of("No"), ENUMERATED_SINGLE_VALUE),
-                new ApplicationInput("unearnedIncome", "noUnemployment", List.of("No"), ENUMERATED_SINGLE_VALUE),
-                new ApplicationInput("unearnedIncome", "noWorkersCompensation", List.of("No"), ENUMERATED_SINGLE_VALUE),
-                new ApplicationInput("unearnedIncome", "noRetirement", List.of("No"), ENUMERATED_SINGLE_VALUE),
-                new ApplicationInput("unearnedIncome", "noTribalPayments", List.of("No"), ENUMERATED_SINGLE_VALUE)
-
-        );
+        PDAcroForm pdAcroForm = submitAndDownloadReceipt();
+        assertThat(pdAcroForm.getField("SOCIAL_SECURITY").getValueAsString()).isEqualTo("Yes");
+        assertThat(pdAcroForm.getField("CHILD_OR_SPOUSAL_SUPPORT").getValueAsString()).isEqualTo("Yes");
+        assertThat(pdAcroForm.getField("SSI").getValueAsString()).isEqualTo("No");
+        assertThat(pdAcroForm.getField("VETERANS_BENEFITS").getValueAsString()).isEqualTo("No");
+        assertThat(pdAcroForm.getField("UNEMPLOYMENT").getValueAsString()).isEqualTo("No");
+        assertThat(pdAcroForm.getField("WORKERS_COMPENSATION").getValueAsString()).isEqualTo("No");
+        assertThat(pdAcroForm.getField("RETIREMENT").getValueAsString()).isEqualTo("No");
+        assertThat(pdAcroForm.getField("TRIBAL_PAYMENTS").getValueAsString()).isEqualTo("No");
     }
 
     @ParameterizedTest
     @CsvSource(value = {
-            "true,false,false",
-            "true,true,true"
+            "Yes,No,No",
+            "Yes,Yes,Yes"
     })
     void shouldAnswerEnergyAssistanceQuestion(
-            Boolean hasEnergyAssistance,
-            Boolean hasMoreThan20ForEnergyAssistance,
+            String hasEnergyAssistance,
+            String hasMoreThan20ForEnergyAssistance,
             String result
     ) {
-        PageData energyAssistancePageData = new PageData();
-        energyAssistancePageData.put(
-                "energyAssistance",
-                InputData.builder()
-                        .value(List.of(hasEnergyAssistance.toString()))
-                        .build()
-        );
+        navigateTo("energyAssistance");
+        testPage.enter("energyAssistance", hasEnergyAssistance);
+        testPage.enter("energyAssistanceMoreThan20", hasMoreThan20ForEnergyAssistance);
 
-        PageData energyAssistanceMoreThan20PageData = new PageData();
-        energyAssistanceMoreThan20PageData.put(
-                "energyAssistanceMoreThan20",
-                InputData.builder()
-                        .value(List.of(hasMoreThan20ForEnergyAssistance.toString()))
-                        .build()
-        );
-        pagesData.putPage("energyAssistance", energyAssistancePageData);
-        pagesData.putPage("energyAssistanceMoreThan20", energyAssistanceMoreThan20PageData);
-
-        data.setPagesData(pagesData);
-
-        List<ApplicationInput> applicationInputs = mappers.map(application, CASEWORKER);
-
-        assertThat(applicationInputs).contains(
-                new ApplicationInput(
-                        "energyAssistanceGroup",
-                        "energyAssistanceInput",
-                        List.of(result),
-                        ENUMERATED_SINGLE_VALUE
-                )
-        );
+        PDAcroForm pdAcroForm = submitAndDownloadReceipt();
+        assertThat(pdAcroForm.getField("RECEIVED_LIHEAP").getValueAsString())
+                .isEqualTo(result);
     }
 
     @Test
     void shouldMapEnergyAssistanceWhenUserReceivedNoAssistance() {
-        PageData energyAssistancePageData = new PageData();
-        energyAssistancePageData.put(
-                "energyAssistance",
-                InputData.builder()
-                        .value(List.of("false"))
-                        .build()
-        );
+        navigateTo("energyAssistance");
+        testPage.enter("energyAssistance", "No");
 
-        pagesData.putPage("energyAssistance", energyAssistancePageData);
-
-        data.setPagesData(pagesData);
-
-        List<ApplicationInput> applicationInputs = mappers.map(application, CASEWORKER);
-
-        assertThat(applicationInputs).contains(
-                new ApplicationInput("energyAssistanceGroup", "energyAssistanceInput", List.of("false"), ENUMERATED_SINGLE_VALUE)
-        );
+        PDAcroForm pdAcroForm = submitAndDownloadReceipt();
+        assertThat(pdAcroForm.getField("RECEIVED_LIHEAP").getValueAsString())
+                .isEqualTo("No");
     }
 
     @Test
     void shouldMapNoForSelfEmployment() {
-        Subworkflows subworkflows = new Subworkflows();
-        Subworkflow subworkflow = new Subworkflow();
-        PagesData pagesData = new PagesData();
-        PageData selfEmploymentPageData = new PageData();
-        selfEmploymentPageData.put("selfEmployment", InputData.builder().value(List.of("false")).build());
-        pagesData.put("selfEmployment", selfEmploymentPageData);
-        PageData paidByTheHourPage = new PageData();
-        paidByTheHourPage.put("paidByTheHour", InputData.builder().value(List.of("false")).build());
-        pagesData.put("paidByTheHour", paidByTheHourPage);
-        PageData payPeriod = new PageData();
-        payPeriod.put("payPeriod", InputData.builder().value(List.of("EVERY_WEEK")).build());
-        pagesData.put("payPeriod", payPeriod);
-        PageData payPerPeriod = new PageData();
-        payPerPeriod.put("incomePerPayPeriod", InputData.builder().value(List.of("1")).build());
-        pagesData.put("incomePerPayPeriod", payPerPeriod);
-        subworkflow.add(pagesData);
-        subworkflows.put("jobs", subworkflow);
-        data.setSubworkflows(subworkflows);
+        navigateTo("incomeByJob");
+        testPage.clickButton("Add a job");
+        testPage.enter("employersName", "someEmployerName");
+        testPage.clickContinue();
+        testPage.enter("selfEmployment", "No");
+        testPage.enter("paidByTheHour", "No");
+        testPage.enter("payPeriod", "Every week");
+        testPage.clickContinue();
+        testPage.enter("incomePerPayPeriod", "1");
+        testPage.clickContinue();
 
-        List<ApplicationInput> applicationInputs = mappers.map(application, CASEWORKER);
-
-        assertThat(applicationInputs).contains(
-                new ApplicationInput("employee", "selfEmployed", List.of("false"), ENUMERATED_SINGLE_VALUE)
-        );
+        PDAcroForm pdAcroForm = submitAndDownloadReceipt();
+        assertThat(pdAcroForm.getField("SELF_EMPLOYED").getValueAsString())
+                .isEqualTo("No");
     }
 
     @Test
     void shouldMapOriginalAddressIfHomeAddressDoesNotUseEnrichedAddress() {
-        List<String> originalCityValue = List.of("originalCity");
-        List<String> originalZipCodeValue = List.of("originalZipCode");
-        List<String> originalApartmentNumber = List.of("originalApt");
-        List<String> originalState = List.of("originalState");
-        homeAddressPageData.putAll(Map.of(
-                "city", InputData.builder().value(originalCityValue).build(),
-                "zipCode", InputData.builder().value(originalZipCodeValue).build(),
-                "apartmentNumber", InputData.builder().value(originalApartmentNumber).build(),
-                "state", InputData.builder().value(originalState).build()));
-        homeAddressValidationPageData.put("useEnrichedAddress", InputData.builder().value(List.of("false")).build());
-
-        List<ApplicationInput> applicationInputs = mappers.map(application, CASEWORKER);
-
-        assertThat(applicationInputs).contains(
-                new ApplicationInput(
-                        "homeAddress",
-                        "selectedCity",
-                        originalCityValue,
-                        ApplicationInputType.SINGLE_VALUE
-                ),
-                new ApplicationInput(
-                        "homeAddress",
-                        "selectedZipCode",
-                        originalZipCodeValue,
-                        ApplicationInputType.SINGLE_VALUE
-                ),
-                new ApplicationInput(
-                        "homeAddress",
-                        "selectedApartmentNumber",
-                        originalApartmentNumber,
-                        ApplicationInputType.SINGLE_VALUE
-                ),
-                new ApplicationInput(
-                        "homeAddress",
-                        "selectedState",
-                        originalState,
-                        ApplicationInputType.SINGLE_VALUE
-                )
-        );
+        navigateTo("homeAddress");
+        String originalStreetAddress = "originalStreetAddress";
+        String originalApt = "originalApt";
+        String originalCity = "originalCity";
+        String originalZipCode = "54321";
+        testPage.enter("streetAddress", originalStreetAddress);
+        testPage.enter("apartmentNumber", originalApt);
+        testPage.enter("city", originalCity);
+        testPage.enter("zipCode", originalZipCode);
+        testPage.enter("sameMailingAddress", "No, use a different address for mail");
+        testPage.clickContinue();
+        testPage.clickButton("Use this address");
+        PDAcroForm pdAcroForm = submitAndDownloadReceipt();
+        assertThat(pdAcroForm.getField("APPLICANT_HOME_STREET_ADDRESS").getValueAsString())
+                .isEqualTo(originalStreetAddress);
+        assertThat(pdAcroForm.getField("APPLICANT_HOME_APT_NUMBER").getValueAsString())
+                .isEqualTo(originalApt);
+        assertThat(pdAcroForm.getField("APPLICANT_HOME_CITY").getValueAsString())
+                .isEqualTo(originalCity);
+        assertThat(pdAcroForm.getField("APPLICANT_HOME_STATE").getValueAsString())
+                .isEqualTo("MN");
+        assertThat(pdAcroForm.getField("APPLICANT_HOME_ZIPCODE").getValueAsString())
+                .isEqualTo(originalZipCode);
     }
 
     @Test
     void shouldMapEnrichedAddressIfHomeAddressUsesEnrichedAddress() {
-        List<String> enrichedCityValue = List.of("testCity");
-        List<String> enrichedZipCodeValue = List.of("testZipCode");
-        List<String> enrichedApartmentNumber = List.of("someApt");
-        List<String> enrichedState = List.of("someState");
-        homeAddressPageData.putAll(Map.of(
-                "enrichedCity", InputData.builder().value(enrichedCityValue).build(),
-                "enrichedZipCode", InputData.builder().value(enrichedZipCodeValue).build(),
-                "enrichedApartmentNumber", InputData.builder().value(enrichedApartmentNumber).build(),
-                "enrichedState", InputData.builder().value(enrichedState).build()));
-        homeAddressValidationPageData.put("useEnrichedAddress", InputData.builder().value(List.of("true")).build());
-
-        List<ApplicationInput> applicationInputs = mappers.map(application, CASEWORKER);
-
-        assertThat(applicationInputs).contains(
-                new ApplicationInput(
-                        "homeAddress",
-                        "selectedCity",
+        navigateTo("homeAddress");
+        testPage.enter("streetAddress", "originalStreetAddress");
+        testPage.enter("apartmentNumber", "originalApt");
+        testPage.enter("city", "originalCity");
+        testPage.enter("zipCode", "54321");
+        testPage.enter("sameMailingAddress", "No, use a different address for mail");
+        String enrichedStreetValue = "testStreet";
+        String enrichedCityValue = "testCity";
+        String enrichedZipCodeValue = "testZipCode";
+        String enrichedApartmentNumber = "someApt";
+        String enrichedState = "someState";
+        when(locationClient.validateAddress(any()))
+                .thenReturn(Optional.of(new Address(
+                        enrichedStreetValue,
                         enrichedCityValue,
-                        ApplicationInputType.SINGLE_VALUE
-                ),
-                new ApplicationInput(
-                        "homeAddress",
-                        "selectedZipCode",
-                        enrichedZipCodeValue,
-                        ApplicationInputType.SINGLE_VALUE
-                ),
-                new ApplicationInput(
-                        "homeAddress",
-                        "selectedApartmentNumber",
-                        enrichedApartmentNumber,
-                        ApplicationInputType.SINGLE_VALUE
-                ),
-                new ApplicationInput(
-                        "homeAddress",
-                        "selectedState",
                         enrichedState,
-                        ApplicationInputType.SINGLE_VALUE
-                )
-        );
+                        enrichedZipCodeValue,
+                        enrichedApartmentNumber,
+                        "Hennepin")));
+        testPage.clickContinue();
+        testPage.clickContinue();
+        PDAcroForm pdAcroForm = submitAndDownloadReceipt();
+        assertThat(pdAcroForm.getField("APPLICANT_HOME_STREET_ADDRESS").getValueAsString())
+                .isEqualTo(enrichedStreetValue);
+        assertThat(pdAcroForm.getField("APPLICANT_HOME_APT_NUMBER").getValueAsString())
+                .isEqualTo(enrichedApartmentNumber);
+        assertThat(pdAcroForm.getField("APPLICANT_HOME_CITY").getValueAsString())
+                .isEqualTo(enrichedCityValue);
+        assertThat(pdAcroForm.getField("APPLICANT_HOME_STATE").getValueAsString())
+                .isEqualTo(enrichedState);
+        assertThat(pdAcroForm.getField("APPLICANT_HOME_ZIPCODE").getValueAsString())
+                .isEqualTo(enrichedZipCodeValue);
     }
 
     @Test
     void shouldMapOriginalHomeAddressToMailingAddressIfSameMailingAddressIsTrueAndUseEnrichedAddressIsFalse() {
-        homeAddressPageData.putAll(Map.of(
-                "zipCode", InputData.builder().value(List.of("someZipCode")).build(),
-                "city", InputData.builder().value(List.of("someCity")).build(),
-                "state", InputData.builder().value(List.of("someState")).build(),
-                "streetAddress", InputData.builder().value(List.of("someStreetAddress")).build(),
-                "apartmentNumber", InputData.builder().value(List.of("someApartmentNumber")).build(),
-                "sameMailingAddress", InputData.builder().value(List.of("true")).build()
-        ));
-
-        homeAddressValidationPageData.put("useEnrichedAddress", InputData.builder().value(List.of("false")).build());
-
-        List<ApplicationInput> applicationInputs = mappers.map(application, CASEWORKER);
-
-        assertThat(applicationInputs).contains(
-                new ApplicationInput(
-                        "mailingAddress",
-                        "selectedZipCode",
-                        List.of("someZipCode"),
-                        ApplicationInputType.SINGLE_VALUE
-                ),
-                new ApplicationInput(
-                        "mailingAddress",
-                        "selectedCity",
-                        List.of("someCity"),
-                        ApplicationInputType.SINGLE_VALUE
-                ),
-                new ApplicationInput(
-                        "mailingAddress",
-                        "selectedState",
-                        List.of("someState"),
-                        ApplicationInputType.SINGLE_VALUE
-                ),
-                new ApplicationInput(
-                        "mailingAddress",
-                        "selectedStreetAddress",
-                        List.of("someStreetAddress"),
-                        ApplicationInputType.SINGLE_VALUE
-                ),
-                new ApplicationInput(
-                        "mailingAddress",
-                        "selectedApartmentNumber",
-                        List.of("someApartmentNumber"),
-                        ApplicationInputType.SINGLE_VALUE
-                )
-        );
+        navigateTo("homeAddress");
+        String originalStreetAddress = "originalStreetAddress";
+        String originalApt = "originalApt";
+        String originalCity = "originalCity";
+        String originalZipCode = "54321";
+        testPage.enter("streetAddress", originalStreetAddress);
+        testPage.enter("apartmentNumber", originalApt);
+        testPage.enter("city", originalCity);
+        testPage.enter("zipCode", originalZipCode);
+        testPage.enter("sameMailingAddress", "Yes, send mail here");
+        testPage.clickContinue();
+        testPage.clickButton("Use this address");
+        PDAcroForm pdAcroForm = submitAndDownloadReceipt();
+        assertThat(pdAcroForm.getField("APPLICANT_MAILING_STREET_ADDRESS").getValueAsString())
+                .isEqualTo(originalStreetAddress);
+        assertThat(pdAcroForm.getField("APPLICANT_MAILING_APT_NUMBER").getValueAsString())
+                .isEqualTo(originalApt);
+        assertThat(pdAcroForm.getField("APPLICANT_MAILING_CITY").getValueAsString())
+                .isEqualTo(originalCity);
+        assertThat(pdAcroForm.getField("APPLICANT_MAILING_STATE").getValueAsString())
+                .isEqualTo("MN");
+        assertThat(pdAcroForm.getField("APPLICANT_MAILING_ZIPCODE").getValueAsString())
+                .isEqualTo(originalZipCode);
     }
 
     @Test
     void shouldMapEnrichedHomeAddressToMailingAddressIfSameMailingAddressIsTrueAndUseEnrichedAddressIsTrue() {
-        homeAddressPageData.putAll(Map.of(
-                "enrichedZipCode", InputData.builder().value(List.of("someZipCode")).build(),
-                "enrichedCity", InputData.builder().value(List.of("someCity")).build(),
-                "enrichedState", InputData.builder().value(List.of("someState")).build(),
-                "enrichedStreetAddress", InputData.builder().value(List.of("someStreetAddress")).build(),
-                "enrichedApartmentNumber", InputData.builder().value(List.of("someApartmentNumber")).build(),
-                "sameMailingAddress", InputData.builder().value(List.of("true")).build()
-        ));
-        homeAddressValidationPageData.put("useEnrichedAddress", InputData.builder().value(List.of("true")).build());
-
-        List<ApplicationInput> applicationInputs = mappers.map(application, CASEWORKER);
-
-        assertThat(applicationInputs).contains(
-                new ApplicationInput(
-                        "mailingAddress",
-                        "selectedZipCode",
-                        List.of("someZipCode"),
-                        ApplicationInputType.SINGLE_VALUE
-                ),
-                new ApplicationInput(
-                        "mailingAddress",
-                        "selectedCity",
-                        List.of("someCity"),
-                        ApplicationInputType.SINGLE_VALUE
-                ),
-                new ApplicationInput(
-                        "mailingAddress",
-                        "selectedState",
-                        List.of("someState"),
-                        ApplicationInputType.SINGLE_VALUE
-                ),
-                new ApplicationInput(
-                        "mailingAddress",
-                        "selectedStreetAddress",
-                        List.of("someStreetAddress"),
-                        ApplicationInputType.SINGLE_VALUE
-                ),
-                new ApplicationInput(
-                        "mailingAddress",
-                        "selectedApartmentNumber",
-                        List.of("someApartmentNumber"),
-                        ApplicationInputType.SINGLE_VALUE
-                )
-        );
+        navigateTo("homeAddress");
+        testPage.enter("streetAddress", "originalStreetAddress");
+        testPage.enter("apartmentNumber", "originalApt");
+        testPage.enter("city", "originalCity");
+        testPage.enter("zipCode", "54321");
+        testPage.enter("sameMailingAddress", "Yes, send mail here");
+        String enrichedStreetValue = "testStreet";
+        String enrichedCityValue = "testCity";
+        String enrichedZipCodeValue = "testZipCode";
+        String enrichedApartmentNumber = "someApt";
+        String enrichedState = "someState";
+        when(locationClient.validateAddress(any()))
+                .thenReturn(Optional.of(new Address(
+                        enrichedStreetValue,
+                        enrichedCityValue,
+                        enrichedState,
+                        enrichedZipCodeValue,
+                        enrichedApartmentNumber,
+                        "Hennepin")));
+        testPage.clickContinue();
+        testPage.clickContinue();
+        PDAcroForm pdAcroForm = submitAndDownloadReceipt();
+        assertThat(pdAcroForm.getField("APPLICANT_MAILING_STREET_ADDRESS").getValueAsString())
+                .isEqualTo(enrichedStreetValue);
+        assertThat(pdAcroForm.getField("APPLICANT_MAILING_APT_NUMBER").getValueAsString())
+                .isEqualTo(enrichedApartmentNumber);
+        assertThat(pdAcroForm.getField("APPLICANT_MAILING_CITY").getValueAsString())
+                .isEqualTo(enrichedCityValue);
+        assertThat(pdAcroForm.getField("APPLICANT_MAILING_STATE").getValueAsString())
+                .isEqualTo(enrichedState);
+        assertThat(pdAcroForm.getField("APPLICANT_MAILING_ZIPCODE").getValueAsString())
+                .isEqualTo(enrichedZipCodeValue);
     }
 
     @Test
     void shouldMapToOriginalMailingAddressIfSameMailingAddressIsFalseAndUseEnrichedAddressIsFalse() {
-        mailingAddressPageData.putAll(Map.of(
-                "zipCode", InputData.builder().value(List.of("someZipCode")).build(),
-                "city", InputData.builder().value(List.of("someCity")).build(),
-                "state", InputData.builder().value(List.of("someState")).build(),
-                "streetAddress", InputData.builder().value(List.of("someStreetAddress")).build(),
-                "apartmentNumber", InputData.builder().value(List.of("someApartmentNumber")).build()
-        ));
+        navigateTo("homeAddress");
+        testPage.enter("streetAddress", "originalHomeStreetAddress");
+        testPage.enter("apartmentNumber", "originalHomeApt");
+        testPage.enter("city", "originalHomeCity");
+        testPage.enter("zipCode", "54321");
+        testPage.enter("sameMailingAddress", "No, use a different address for mail");
+        testPage.clickContinue();
+        testPage.clickButton("Use this address");
+        String originalStreetAddress = "originalStreetAddress";
+        String originalApt = "originalApt";
+        String originalCity = "originalCity";
+        String originalState = "IL";
+        String originalZipCode = "54321";
+        testPage.enter("streetAddress", originalStreetAddress);
+        testPage.enter("apartmentNumber", originalApt);
+        testPage.enter("city", originalCity);
+        testPage.enter("state", originalState);
+        testPage.enter("zipCode", originalZipCode);
+        testPage.clickContinue();
+        testPage.clickButton("Use this address");
 
-        mailingAddressValidationPageData.put("useEnrichedAddress", InputData.builder().value(List.of("false")).build());
-
-        homeAddressPageData.put("sameMailingAddress", InputData.builder().value(List.of("false")).build());
-
-        List<ApplicationInput> applicationInputs = mappers.map(application, CASEWORKER);
-
-        assertThat(applicationInputs).contains(
-                new ApplicationInput(
-                        "mailingAddress",
-                        "selectedZipCode",
-                        List.of("someZipCode"),
-                        ApplicationInputType.SINGLE_VALUE
-                ),
-                new ApplicationInput(
-                        "mailingAddress",
-                        "selectedCity",
-                        List.of("someCity"),
-                        ApplicationInputType.SINGLE_VALUE
-                ),
-                new ApplicationInput(
-                        "mailingAddress",
-                        "selectedState",
-                        List.of("someState"),
-                        ApplicationInputType.SINGLE_VALUE
-                ),
-                new ApplicationInput(
-                        "mailingAddress",
-                        "selectedStreetAddress",
-                        List.of("someStreetAddress"),
-                        ApplicationInputType.SINGLE_VALUE
-                ),
-                new ApplicationInput(
-                        "mailingAddress",
-                        "selectedApartmentNumber",
-                        List.of("someApartmentNumber"),
-                        ApplicationInputType.SINGLE_VALUE
-                )
-        );
+        PDAcroForm pdAcroForm = submitAndDownloadReceipt();
+        assertThat(pdAcroForm.getField("APPLICANT_MAILING_STREET_ADDRESS").getValueAsString())
+                .isEqualTo(originalStreetAddress);
+        assertThat(pdAcroForm.getField("APPLICANT_MAILING_APT_NUMBER").getValueAsString())
+                .isEqualTo(originalApt);
+        assertThat(pdAcroForm.getField("APPLICANT_MAILING_CITY").getValueAsString())
+                .isEqualTo(originalCity);
+        assertThat(pdAcroForm.getField("APPLICANT_MAILING_STATE").getValueAsString())
+                .isEqualTo(originalState);
+        assertThat(pdAcroForm.getField("APPLICANT_MAILING_ZIPCODE").getValueAsString())
+                .isEqualTo(originalZipCode);
     }
 
     @Test
     void shouldMapToEnrichedMailingAddressIfSameMailingAddressIsFalseAndUseEnrichedAddressIsTrue() {
-        mailingAddressPageData.putAll(Map.of(
-                "enrichedZipCode", InputData.builder().value(List.of("someZipCode")).build(),
-                "enrichedCity", InputData.builder().value(List.of("someCity")).build(),
-                "enrichedState", InputData.builder().value(List.of("someState")).build(),
-                "enrichedStreetAddress", InputData.builder().value(List.of("someStreetAddress")).build(),
-                "enrichedApartmentNumber", InputData.builder().value(List.of("someApartmentNumber")).build()
-        ));
+        navigateTo("homeAddress");
+        testPage.enter("streetAddress", "originalHomeStreetAddress");
+        testPage.enter("apartmentNumber", "originalHomeApt");
+        testPage.enter("city", "originalHomeCity");
+        testPage.enter("zipCode", "54321");
+        testPage.enter("sameMailingAddress", "No, use a different address for mail");
+        testPage.clickContinue();
+        testPage.clickButton("Use this address");
+        testPage.enter("streetAddress", "originalStreetAddress");
+        testPage.enter("apartmentNumber", "originalApt");
+        testPage.enter("city", "originalCity");
+        testPage.enter("state", "IL");
+        testPage.enter("zipCode", "54321");
+        String enrichedStreetValue = "testStreet";
+        String enrichedCityValue = "testCity";
+        String enrichedZipCodeValue = "testZipCode";
+        String enrichedApartmentNumber = "someApt";
+        String enrichedState = "someState";
+        when(locationClient.validateAddress(any()))
+                .thenReturn(Optional.of(new Address(
+                        enrichedStreetValue,
+                        enrichedCityValue,
+                        enrichedState,
+                        enrichedZipCodeValue,
+                        enrichedApartmentNumber,
+                        "Hennepin")));
+        testPage.clickContinue();
+        testPage.clickContinue();
 
-        mailingAddressValidationPageData.put("useEnrichedAddress", InputData.builder().value(List.of("true")).build());
+        PDAcroForm pdAcroForm = submitAndDownloadReceipt();
+        assertThat(pdAcroForm.getField("APPLICANT_MAILING_STREET_ADDRESS").getValueAsString())
+                .isEqualTo(enrichedStreetValue);
+        assertThat(pdAcroForm.getField("APPLICANT_MAILING_APT_NUMBER").getValueAsString())
+                .isEqualTo(enrichedApartmentNumber);
+        assertThat(pdAcroForm.getField("APPLICANT_MAILING_CITY").getValueAsString())
+                .isEqualTo(enrichedCityValue);
+        assertThat(pdAcroForm.getField("APPLICANT_MAILING_STATE").getValueAsString())
+                .isEqualTo(enrichedState);
+        assertThat(pdAcroForm.getField("APPLICANT_MAILING_ZIPCODE").getValueAsString())
+                .isEqualTo(enrichedZipCodeValue);
+    }
 
-        homeAddressPageData.put("sameMailingAddress", InputData.builder().value(List.of("false")).build());
+    private PDAcroForm submitAndDownloadReceipt() {
+        navigateTo("signThisApplication");
+        testPage.enter("applicantSignature", "someSignature");
+        testPage.clickButton("Submit");
+        SuccessPage successPage = new SuccessPage(driver);
+        successPage.downloadReceipt();
+        await().until(() -> path.toFile().listFiles().length > 0);
 
-        List<ApplicationInput> applicationInputs = mappers.map(application, CASEWORKER);
-
-        assertThat(applicationInputs).contains(
-                new ApplicationInput(
-                        "mailingAddress",
-                        "selectedZipCode",
-                        List.of("someZipCode"),
-                        ApplicationInputType.SINGLE_VALUE
-                ),
-                new ApplicationInput(
-                        "mailingAddress",
-                        "selectedCity",
-                        List.of("someCity"),
-                        ApplicationInputType.SINGLE_VALUE
-                ),
-                new ApplicationInput(
-                        "mailingAddress",
-                        "selectedState",
-                        List.of("someState"),
-                        ApplicationInputType.SINGLE_VALUE
-                ),
-                new ApplicationInput(
-                        "mailingAddress",
-                        "selectedStreetAddress",
-                        List.of("someStreetAddress"),
-                        ApplicationInputType.SINGLE_VALUE
-                ),
-                new ApplicationInput(
-                        "mailingAddress",
-                        "selectedApartmentNumber",
-                        List.of("someApartmentNumber"),
-                        ApplicationInputType.SINGLE_VALUE
-                )
-        );
+        File pdfFile = Arrays.stream(path.toFile().listFiles()).findFirst().orElseThrow();
+        try {
+            return PDDocument.load(pdfFile).getDocumentCatalog().getAcroForm();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/src/test/java/org/codeforamerica/shiba/pages/ConditionalInputsPageTest.java
+++ b/src/test/java/org/codeforamerica/shiba/pages/ConditionalInputsPageTest.java
@@ -1,5 +1,6 @@
 package org.codeforamerica.shiba.pages;
 
+import org.codeforamerica.shiba.AbstractExistingStartTimePageTest;
 import org.codeforamerica.shiba.YamlPropertySourceFactory;
 import org.codeforamerica.shiba.pages.config.ApplicationConfiguration;
 import org.junit.jupiter.api.BeforeEach;
@@ -28,7 +29,7 @@ public class ConditionalInputsPageTest extends AbstractExistingStartTimePageTest
 
     @Override
     @BeforeEach
-    void setUp() throws IOException {
+    protected void setUp() throws IOException {
         super.setUp();
         staticMessageSource.addMessage("option1", Locale.US, "option 1");
         staticMessageSource.addMessage("option2", Locale.US, "option 2");

--- a/src/test/java/org/codeforamerica/shiba/pages/ConditionalRenderingPageTest.java
+++ b/src/test/java/org/codeforamerica/shiba/pages/ConditionalRenderingPageTest.java
@@ -1,5 +1,6 @@
 package org.codeforamerica.shiba.pages;
 
+import org.codeforamerica.shiba.AbstractExistingStartTimePageTest;
 import org.codeforamerica.shiba.YamlPropertySourceFactory;
 import org.codeforamerica.shiba.pages.config.ApplicationConfiguration;
 import org.junit.jupiter.api.BeforeEach;
@@ -35,7 +36,7 @@ public class ConditionalRenderingPageTest extends AbstractExistingStartTimePageT
     }
 
     @BeforeEach
-    void setUp() throws IOException {
+    protected void setUp() throws IOException {
         super.setUp();
         staticMessageSource.addMessage("first-page-title", Locale.US, firstPageTitle);
         staticMessageSource.addMessage("second-page-title", Locale.US, secondPageTitle);

--- a/src/test/java/org/codeforamerica/shiba/pages/EnrichmentPageTest.java
+++ b/src/test/java/org/codeforamerica/shiba/pages/EnrichmentPageTest.java
@@ -1,5 +1,6 @@
 package org.codeforamerica.shiba.pages;
 
+import org.codeforamerica.shiba.AbstractExistingStartTimePageTest;
 import org.codeforamerica.shiba.YamlPropertySourceFactory;
 import org.codeforamerica.shiba.pages.config.ApplicationConfiguration;
 import org.codeforamerica.shiba.pages.data.ApplicationData;

--- a/src/test/java/org/codeforamerica/shiba/pages/InputsPageTest.java
+++ b/src/test/java/org/codeforamerica/shiba/pages/InputsPageTest.java
@@ -1,5 +1,6 @@
 package org.codeforamerica.shiba.pages;
 
+import org.codeforamerica.shiba.AbstractExistingStartTimePageTest;
 import org.codeforamerica.shiba.YamlPropertySourceFactory;
 import org.codeforamerica.shiba.pages.config.ApplicationConfiguration;
 import org.junit.jupiter.api.BeforeEach;
@@ -41,7 +42,7 @@ public class InputsPageTest extends AbstractExistingStartTimePageTest {
 
     @Override
     @BeforeEach
-    void setUp() throws IOException {
+    protected void setUp() throws IOException {
         super.setUp();
         staticMessageSource.addMessage("first-page-title", Locale.US, "firstPageTitle");
         staticMessageSource.addMessage("next-page-title", Locale.US, "nextPageTitle");

--- a/src/test/java/org/codeforamerica/shiba/pages/LandmarkPageTest.java
+++ b/src/test/java/org/codeforamerica/shiba/pages/LandmarkPageTest.java
@@ -1,5 +1,6 @@
 package org.codeforamerica.shiba.pages;
 
+import org.codeforamerica.shiba.AbstractStaticMessageSourcePageTest;
 import org.codeforamerica.shiba.YamlPropertySourceFactory;
 import org.codeforamerica.shiba.pages.config.ApplicationConfiguration;
 import org.codeforamerica.shiba.pages.data.ApplicationData;
@@ -68,7 +69,7 @@ public class LandmarkPageTest extends AbstractStaticMessageSourcePageTest {
 
     @Override
     @BeforeEach
-    void setUp() throws IOException {
+    protected void setUp() throws IOException {
         super.setUp();
         staticMessageSource.addMessage("first-page-title", Locale.US, firstPageTitle);
         staticMessageSource.addMessage("fourth-page-title", Locale.US, "fourth page title");

--- a/src/test/java/org/codeforamerica/shiba/pages/PageDatasourcePageTest.java
+++ b/src/test/java/org/codeforamerica/shiba/pages/PageDatasourcePageTest.java
@@ -1,5 +1,6 @@
 package org.codeforamerica.shiba.pages;
 
+import org.codeforamerica.shiba.AbstractExistingStartTimePageTest;
 import org.codeforamerica.shiba.YamlPropertySourceFactory;
 import org.codeforamerica.shiba.pages.config.ApplicationConfiguration;
 import org.junit.jupiter.api.BeforeEach;
@@ -33,7 +34,7 @@ public class PageDatasourcePageTest extends AbstractExistingStartTimePageTest {
 
     @Override
     @BeforeEach
-    void setUp() throws IOException {
+    protected void setUp() throws IOException {
         super.setUp();
         staticMessageSource.addMessage("first-page-title", Locale.US, "firstPageTitle");
         staticMessageSource.addMessage("static-page-with-datasource-inputs-title", Locale.US, staticPageWithDatasourceInputsTitle);

--- a/src/test/java/org/codeforamerica/shiba/pages/PageModelPageTest.java
+++ b/src/test/java/org/codeforamerica/shiba/pages/PageModelPageTest.java
@@ -1,5 +1,6 @@
 package org.codeforamerica.shiba.pages;
 
+import org.codeforamerica.shiba.AbstractExistingStartTimePageTest;
 import org.codeforamerica.shiba.YamlPropertySourceFactory;
 import org.codeforamerica.shiba.pages.config.ApplicationConfiguration;
 import org.junit.jupiter.api.BeforeEach;
@@ -28,7 +29,7 @@ public class PageModelPageTest extends AbstractExistingStartTimePageTest {
 
     @Override
     @BeforeEach
-    void setUp() throws java.io.IOException {
+    protected void setUp() throws java.io.IOException {
         super.setUp();
 
         title = "first page title";

--- a/src/test/java/org/codeforamerica/shiba/pages/StartTimerPageTest.java
+++ b/src/test/java/org/codeforamerica/shiba/pages/StartTimerPageTest.java
@@ -1,5 +1,6 @@
 package org.codeforamerica.shiba.pages;
 
+import org.codeforamerica.shiba.AbstractStaticMessageSourcePageTest;
 import org.codeforamerica.shiba.YamlPropertySourceFactory;
 import org.codeforamerica.shiba.pages.config.ApplicationConfiguration;
 import org.codeforamerica.shiba.pages.data.ApplicationData;

--- a/src/test/java/org/codeforamerica/shiba/pages/SubWorkflowPageTest.java
+++ b/src/test/java/org/codeforamerica/shiba/pages/SubWorkflowPageTest.java
@@ -1,5 +1,6 @@
 package org.codeforamerica.shiba.pages;
 
+import org.codeforamerica.shiba.AbstractExistingStartTimePageTest;
 import org.codeforamerica.shiba.YamlPropertySourceFactory;
 import org.codeforamerica.shiba.pages.config.ApplicationConfiguration;
 import org.codeforamerica.shiba.pages.events.PageEventPublisher;

--- a/src/test/java/org/codeforamerica/shiba/pages/SubmitPageTest.java
+++ b/src/test/java/org/codeforamerica/shiba/pages/SubmitPageTest.java
@@ -1,5 +1,6 @@
 package org.codeforamerica.shiba.pages;
 
+import org.codeforamerica.shiba.AbstractStaticMessageSourcePageTest;
 import org.codeforamerica.shiba.County;
 import org.codeforamerica.shiba.YamlPropertySourceFactory;
 import org.codeforamerica.shiba.application.Application;

--- a/src/test/java/org/codeforamerica/shiba/pages/UserDecisionNavigationPageTest.java
+++ b/src/test/java/org/codeforamerica/shiba/pages/UserDecisionNavigationPageTest.java
@@ -1,5 +1,6 @@
 package org.codeforamerica.shiba.pages;
 
+import org.codeforamerica.shiba.AbstractExistingStartTimePageTest;
 import org.codeforamerica.shiba.YamlPropertySourceFactory;
 import org.codeforamerica.shiba.pages.config.ApplicationConfiguration;
 import org.codeforamerica.shiba.pages.data.ApplicationData;
@@ -53,7 +54,7 @@ public class UserDecisionNavigationPageTest extends AbstractExistingStartTimePag
     }
 
     @BeforeEach
-    void setUp() throws IOException {
+    protected void setUp() throws IOException {
         super.setUp();
         staticMessageSource.addMessage("option-zero-page-title", Locale.US, optionZeroPageTitle);
         staticMessageSource.addMessage("option-one-page-title", Locale.US, optionOnePageTitle);

--- a/src/test/java/org/codeforamerica/shiba/pages/ValidationPageTest.java
+++ b/src/test/java/org/codeforamerica/shiba/pages/ValidationPageTest.java
@@ -1,5 +1,6 @@
 package org.codeforamerica.shiba.pages;
 
+import org.codeforamerica.shiba.AbstractExistingStartTimePageTest;
 import org.codeforamerica.shiba.YamlPropertySourceFactory;
 import org.codeforamerica.shiba.pages.config.ApplicationConfiguration;
 import org.junit.jupiter.api.BeforeEach;
@@ -53,7 +54,7 @@ public class ValidationPageTest extends AbstractExistingStartTimePageTest {
 
     @Override
     @BeforeEach
-    void setUp() throws IOException {
+    protected void setUp() throws IOException {
         super.setUp();
         testPage = new Page(driver);
         staticMessageSource.addMessage("first-page-title", Locale.US, firstPageTitle);

--- a/src/test/java/org/codeforamerica/shiba/pages/YesNoAnswerPageTest.java
+++ b/src/test/java/org/codeforamerica/shiba/pages/YesNoAnswerPageTest.java
@@ -1,5 +1,6 @@
 package org.codeforamerica.shiba.pages;
 
+import org.codeforamerica.shiba.AbstractExistingStartTimePageTest;
 import org.codeforamerica.shiba.YamlPropertySourceFactory;
 import org.codeforamerica.shiba.pages.config.ApplicationConfiguration;
 import org.junit.jupiter.api.BeforeEach;
@@ -30,7 +31,7 @@ public class YesNoAnswerPageTest extends AbstractExistingStartTimePageTest {
     }
 
     @BeforeEach
-    void setUp() throws IOException {
+    protected void setUp() throws IOException {
         super.setUp();
         staticMessageSource.addMessage("answer-page", Locale.US, answerPage);
     }


### PR DESCRIPTION
Test the PDF output using the UI with Selenium and the pages framework to set up the input data and the pdfbox library to assert against the output. This makes for tests that feel more natural to read and write and allows them to capture the true end-to-end experience of our system. This also helps to keep our mappers from diverging from the pages configuration.

As part of this change, some of the mappers were also updated to be null safe to allow for better test isolation in the pdf integration test, such that only the relevant pages in the UI need to be completed to test specific mappings. These mappers were previously not null safe because they implicitly baked in knowledge around page validations. In general, it seems like a better practice to design all of our mappers to be null safe such that there is no need to rely on these page configurations that could change.