### PR TITLE
Assorted test cleanup

### DIFF
--- a/.github/workflows/run-tests-on-pr.yml
+++ b/.github/workflows/run-tests-on-pr.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Test with Gradle
-      run: ./gradlew clean testAll -i
+      run: ./gradlew clean testAll
       env:
         S3_BUCKET: ${{ secrets.S3_TEST_BUCKET }}
         AWS_ACCESS_KEY: ${{ secrets.CLOUD_AWS_CREDENTIALS_ACCESS_KEY }}

--- a/.github/workflows/run-tests-on-pr.yml
+++ b/.github/workflows/run-tests-on-pr.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Test with Gradle
-      run: ./gradlew clean testAll
+      run: ./gradlew clean testAll -i
       env:
         S3_BUCKET: ${{ secrets.S3_TEST_BUCKET }}
         AWS_ACCESS_KEY: ${{ secrets.CLOUD_AWS_CREDENTIALS_ACCESS_KEY }}

--- a/.github/workflows/run-tests-on-pr.yml
+++ b/.github/workflows/run-tests-on-pr.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Test with Gradle
-      run: ./gradlew clean testAll --info
+      run: ./gradlew clean testAll
       env:
         S3_BUCKET: ${{ secrets.S3_TEST_BUCKET }}
         AWS_ACCESS_KEY: ${{ secrets.CLOUD_AWS_CREDENTIALS_ACCESS_KEY }}

--- a/.github/workflows/run-tests-on-pr.yml
+++ b/.github/workflows/run-tests-on-pr.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Test with Gradle
-      run: ./gradlew clean testAll
+      run: ./gradlew clean testAll --info
       env:
         S3_BUCKET: ${{ secrets.S3_TEST_BUCKET }}
         AWS_ACCESS_KEY: ${{ secrets.CLOUD_AWS_CREDENTIALS_ACCESS_KEY }}

--- a/build.gradle
+++ b/build.gradle
@@ -169,7 +169,9 @@ test {
         showCauses true
         showStackTraces true
 
-        showStandardStreams = false
+        // remove standard output/error logging from --info builds
+        // by assigning only 'failed' and 'skipped' events
+        info.events = ["failed", "skipped"]
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -163,7 +163,11 @@ def testAll = tasks.register("testAll", Test) {
 test {
     useJUnitPlatform()
     testLogging {
-        exceptionFormat = 'full'
+        events 'FAILED'
+        showExceptions true
+        exceptionFormat "full"
+        showCauses true
+        showStackTraces true
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -163,11 +163,7 @@ def testAll = tasks.register("testAll", Test) {
 test {
     useJUnitPlatform()
     testLogging {
-        events 'FAILED'
-        showExceptions true
-        exceptionFormat "full"
-        showCauses true
-        showStackTraces true
+        exceptionFormat = 'full'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -154,7 +154,6 @@ def dbTest = tasks.register("dbTest", Test) {
 
 def testAll = tasks.register("testAll", Test) {
     Test task ->
-        task.testLogging { exceptionFormat = 'full' }
         task.dependsOn(unitTest)
         task.dependsOn(dbTest)
 
@@ -163,7 +162,14 @@ def testAll = tasks.register("testAll", Test) {
 test {
     useJUnitPlatform()
     testLogging {
-        exceptionFormat = 'full'
+        events "passed", "skipped", "failed"
+
+        showExceptions true
+        exceptionFormat "full"
+        showCauses true
+        showStackTraces true
+
+        showStandardStreams = false
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -135,6 +135,13 @@ compileJava.inputs.files(processResources)
 
 def unitTest = tasks.register("unitTest", Test) {
     Test task ->
+        task.testLogging {
+            exceptionFormat = 'full'
+            events "failed", "passed", "skipped"
+            showStackTraces true
+            showCauses true
+            showExceptions true
+        }
         task.useJUnitPlatform {
             JUnitPlatformOptions options ->
                 options.excludeTags("db", "externalService")
@@ -144,6 +151,13 @@ def unitTest = tasks.register("unitTest", Test) {
 
 def dbTest = tasks.register("dbTest", Test) {
     Test task ->
+        task.testLogging {
+            exceptionFormat = 'full'
+            events "failed", "passed", "skipped"
+            showStackTraces true
+            showCauses true
+            showExceptions true
+        }
         task.useJUnitPlatform {
             JUnitPlatformOptions options ->
                 options.includeTags 'db'
@@ -156,23 +170,17 @@ def testAll = tasks.register("testAll", Test) {
     Test task ->
         task.dependsOn(unitTest)
         task.dependsOn(dbTest)
-
 }
 
 test {
-    useJUnitPlatform()
     testLogging {
-        events "passed", "skipped", "failed"
-
-        showExceptions true
-        exceptionFormat "full"
-        showCauses true
+        exceptionFormat = 'full'
+        events "failed", "passed", "skipped"
         showStackTraces true
-
-        // remove standard output/error logging from --info builds
-        // by assigning only 'failed' and 'skipped' events
-        info.events = ["failed", "skipped"]
+        showCauses true
+        showExceptions true
     }
+    useJUnitPlatform()
 }
 
 tasks.withType(Test).configureEach {

--- a/src/test/java/org/codeforamerica/shiba/AbstractBasePageTest.java
+++ b/src/test/java/org/codeforamerica/shiba/AbstractBasePageTest.java
@@ -46,7 +46,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 
-@SpringBootTest(webEnvironment = RANDOM_PORT, properties = {"spring.main.allow-bean-definition-overriding=true"})
+@SpringBootTest(webEnvironment = RANDOM_PORT)
 @ActiveProfiles("test")
 @ExtendWith(SpringExtension.class)
 public abstract class AbstractBasePageTest {

--- a/src/test/java/org/codeforamerica/shiba/AbstractBasePageTest.java
+++ b/src/test/java/org/codeforamerica/shiba/AbstractBasePageTest.java
@@ -48,7 +48,6 @@ import static org.springframework.boot.test.context.SpringBootTest.WebEnvironmen
 
 @SpringBootTest(webEnvironment = RANDOM_PORT)
 @ActiveProfiles("test")
-@ExtendWith(SpringExtension.class)
 public abstract class AbstractBasePageTest {
     public static final String PROGRAM_SNAP = "Food (SNAP)";
     public static final String PROGRAM_CASH = "Cash programs";

--- a/src/test/java/org/codeforamerica/shiba/AbstractRepositoryTest.java
+++ b/src/test/java/org/codeforamerica/shiba/AbstractRepositoryTest.java
@@ -1,0 +1,25 @@
+package org.codeforamerica.shiba;
+
+import org.codeforamerica.shiba.application.ApplicationDataEncryptor;
+import org.codeforamerica.shiba.application.ApplicationRepository;
+import org.codeforamerica.shiba.application.StringEncryptor;
+import org.codeforamerica.shiba.research.ResearchDataRepository;
+import org.junit.jupiter.api.Tag;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.jdbc.JdbcTest;
+import org.springframework.boot.test.autoconfigure.json.AutoConfigureJson;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.jdbc.Sql;
+
+import static org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace.NONE;
+
+@ActiveProfiles("test")
+@Tag("db")
+@JdbcTest
+@AutoConfigureTestDatabase(replace = NONE)
+@Sql(statements = {"ALTER SEQUENCE application_id RESTART WITH 12"})
+@ContextConfiguration(classes = {NonSessionScopedApplicationData.class, ApplicationDataEncryptor.class, StringEncryptor.class, ApplicationRepository.class, ResearchDataRepository.class})
+@AutoConfigureJson
+public class AbstractRepositoryTest {
+}

--- a/src/test/java/org/codeforamerica/shiba/AbstractRepositoryTest.java
+++ b/src/test/java/org/codeforamerica/shiba/AbstractRepositoryTest.java
@@ -18,7 +18,7 @@ import static org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTest
 @Tag("db")
 @JdbcTest
 @AutoConfigureTestDatabase(replace = NONE)
-@Sql(statements = {"ALTER SEQUENCE application_id RESTART WITH 12"})
+@Sql(statements = {"ALTER SEQUENCE application_id RESTART WITH 12", "TRUNCATE TABLE applications"})
 @ContextConfiguration(classes = {NonSessionScopedApplicationData.class, ApplicationDataEncryptor.class, StringEncryptor.class, ApplicationRepository.class, ResearchDataRepository.class})
 @AutoConfigureJson
 public class AbstractRepositoryTest {

--- a/src/test/java/org/codeforamerica/shiba/NonSessionScopedApplicationData.java
+++ b/src/test/java/org/codeforamerica/shiba/NonSessionScopedApplicationData.java
@@ -1,0 +1,13 @@
+package org.codeforamerica.shiba;
+
+import org.codeforamerica.shiba.pages.data.ApplicationData;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+@TestConfiguration
+public class NonSessionScopedApplicationData {
+    @Bean
+    public ApplicationData applicationData() {
+        return new ApplicationData();
+    }
+}

--- a/src/test/java/org/codeforamerica/shiba/ResearchDataRepositoryTest.java
+++ b/src/test/java/org/codeforamerica/shiba/ResearchDataRepositoryTest.java
@@ -3,31 +3,25 @@ package org.codeforamerica.shiba;
 import org.codeforamerica.shiba.application.FlowType;
 import org.codeforamerica.shiba.research.ResearchData;
 import org.codeforamerica.shiba.research.ResearchDataRepository;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.jdbc.Sql;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import java.time.Clock;
 import java.time.LocalDate;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.NONE;
 
-@SpringBootTest(webEnvironment = NONE)
-@ActiveProfiles("test")
-@Sql(statements = {"TRUNCATE TABLE research"})
-@Tag("db")
-class ResearchDataRepositoryTest {
+class ResearchDataRepositoryTest extends AbstractRepositoryTest {
     @Autowired
-    ResearchDataRepository researchDataRepository;
+    private ResearchDataRepository researchDataRepository;
+
+    @MockBean
+    private Clock clock;
 
     @Autowired
-    JdbcTemplate jdbcTemplate;
+    private JdbcTemplate jdbcTemplate;
 
     @Test
     void savesResearchData() {

--- a/src/test/java/org/codeforamerica/shiba/ResearchDataRepositoryTest.java
+++ b/src/test/java/org/codeforamerica/shiba/ResearchDataRepositoryTest.java
@@ -19,7 +19,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.NONE;
 
 @SpringBootTest(webEnvironment = NONE)
-@ExtendWith(SpringExtension.class)
 @ActiveProfiles("test")
 @Sql(statements = {"TRUNCATE TABLE research"})
 @Tag("db")

--- a/src/test/java/org/codeforamerica/shiba/ResearchDataRepositoryTest.java
+++ b/src/test/java/org/codeforamerica/shiba/ResearchDataRepositoryTest.java
@@ -16,8 +16,9 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import java.time.LocalDate;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.NONE;
 
-@SpringBootTest
+@SpringBootTest(webEnvironment = NONE)
 @ExtendWith(SpringExtension.class)
 @ActiveProfiles("test")
 @Sql(statements = {"TRUNCATE TABLE research"})

--- a/src/test/java/org/codeforamerica/shiba/SecurityConfigurationTest.java
+++ b/src/test/java/org/codeforamerica/shiba/SecurityConfigurationTest.java
@@ -35,7 +35,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
         "shiba.password=somePassword"
 })
 @ActiveProfiles("test")
-@ExtendWith(SpringExtension.class)
 class SecurityConfigurationTest {
     MockMvc mockMvc;
 

--- a/src/test/java/org/codeforamerica/shiba/application/ApplicationDataEncryptorTest.java
+++ b/src/test/java/org/codeforamerica/shiba/application/ApplicationDataEncryptorTest.java
@@ -3,10 +3,8 @@ package org.codeforamerica.shiba.application;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.codeforamerica.shiba.pages.data.ApplicationData;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.autoconfigure.json.JsonTest;
 import org.springframework.boot.test.mock.mockito.SpyBean;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.io.IOException;
 import java.security.GeneralSecurityException;
@@ -15,7 +13,6 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
-@ExtendWith(SpringExtension.class)
 @JsonTest
 class ApplicationDataEncryptorTest {
     @SpyBean

--- a/src/test/java/org/codeforamerica/shiba/application/ApplicationRepositoryTest.java
+++ b/src/test/java/org/codeforamerica/shiba/application/ApplicationRepositoryTest.java
@@ -1,20 +1,16 @@
-package org.codeforamerica.shiba.metrics;
+package org.codeforamerica.shiba.application;
 
+import org.codeforamerica.shiba.AbstractRepositoryTest;
 import org.codeforamerica.shiba.County;
-import org.codeforamerica.shiba.application.*;
 import org.codeforamerica.shiba.pages.Sentiment;
 import org.codeforamerica.shiba.pages.data.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.jdbc.Sql;
 
 import java.time.*;
 import java.time.temporal.ChronoUnit;
@@ -26,25 +22,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.codeforamerica.shiba.County.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
-import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.NONE;
 
-@SpringBootTest(webEnvironment = NONE)
-@ActiveProfiles("test")
-@Sql(statements = {"ALTER SEQUENCE application_id RESTART WITH 12", "TRUNCATE TABLE applications"})
-@Tag("db")
-class ApplicationRepositoryTest {
+class ApplicationRepositoryTest extends AbstractRepositoryTest {
+    @Autowired
+    private ApplicationRepository applicationRepository;
 
     @Autowired
-    ApplicationRepository applicationRepository;
-
-    @Autowired
-    JdbcTemplate jdbcTemplate;
-
-    @Autowired
-    ApplicationFactory applicationFactory;
+    private JdbcTemplate jdbcTemplate;
 
     @MockBean
-    Clock clock;
+    private Clock clock;
 
     @Test
     void shouldGenerateIdForNextApplication() {
@@ -179,10 +166,7 @@ class ApplicationRepositoryTest {
     }
 
     @Nested
-    @SpringBootTest(webEnvironment = NONE)
-    @ActiveProfiles("test")
-    @Sql(statements = {"TRUNCATE TABLE applications"})
-    class EncryptionAndDecryption {
+    class EncryptionAndDecryption extends AbstractRepositoryTest {
         ApplicationRepository applicationRepositoryWithMockEncryptor;
         @SuppressWarnings("unchecked")
         Encryptor<ApplicationData> mockEncryptor = mock(Encryptor.class);
@@ -277,10 +261,7 @@ class ApplicationRepositoryTest {
     }
 
     @Nested
-    @SpringBootTest(webEnvironment = NONE)
-    @ActiveProfiles("test")
-    @Sql(statements = {"TRUNCATE TABLE applications"})
-    class MetricsQueries {
+    class MetricsQueries extends AbstractRepositoryTest {
         County defaultCounty = County.Other;
 
         ZonedDateTime defaultCompletedAt = ZonedDateTime.now(ZoneOffset.UTC);

--- a/src/test/java/org/codeforamerica/shiba/application/parsers/AbstractParserTest.java
+++ b/src/test/java/org/codeforamerica/shiba/application/parsers/AbstractParserTest.java
@@ -1,0 +1,18 @@
+package org.codeforamerica.shiba.application.parsers;
+
+import org.codeforamerica.shiba.pages.config.FeatureFlagConfiguration;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.NONE;
+
+@SpringBootTest(webEnvironment = NONE, classes = {ParserTestConfiguration.class})
+@ActiveProfiles("test")
+public class AbstractParserTest {
+    @Autowired
+    protected ParsingConfiguration parsingConfiguration;
+
+    @Autowired
+    protected FeatureFlagConfiguration featureFlagConfiguration;
+}

--- a/src/test/java/org/codeforamerica/shiba/application/parsers/CountyParserTest.java
+++ b/src/test/java/org/codeforamerica/shiba/application/parsers/CountyParserTest.java
@@ -7,7 +7,6 @@ import org.codeforamerica.shiba.YamlPropertySourceFactory;
 import org.codeforamerica.shiba.pages.data.ApplicationData;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -15,7 +14,6 @@ import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.util.List;
 import java.util.Map;
@@ -25,7 +23,6 @@ import static org.springframework.boot.test.context.SpringBootTest.WebEnvironmen
 
 @SpringBootTest(webEnvironment = NONE)
 @ActiveProfiles("test")
-@ExtendWith(SpringExtension.class)
 class CountyParserTest {
     @Autowired
     CountyParser countyParser;

--- a/src/test/java/org/codeforamerica/shiba/application/parsers/CountyParserTest.java
+++ b/src/test/java/org/codeforamerica/shiba/application/parsers/CountyParserTest.java
@@ -22,7 +22,7 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@SpringBootTest(properties = {"spring.main.allow-bean-definition-overriding=true"})
+@SpringBootTest
 @ActiveProfiles("test")
 @ExtendWith(SpringExtension.class)
 class CountyParserTest {

--- a/src/test/java/org/codeforamerica/shiba/application/parsers/CountyParserTest.java
+++ b/src/test/java/org/codeforamerica/shiba/application/parsers/CountyParserTest.java
@@ -3,44 +3,24 @@ package org.codeforamerica.shiba.application.parsers;
 import org.codeforamerica.shiba.County;
 import org.codeforamerica.shiba.PageDataBuilder;
 import org.codeforamerica.shiba.PagesDataBuilder;
-import org.codeforamerica.shiba.YamlPropertySourceFactory;
 import org.codeforamerica.shiba.pages.data.ApplicationData;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.PropertySource;
-import org.springframework.test.context.ActiveProfiles;
 
 import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.NONE;
 
-@SpringBootTest(webEnvironment = NONE)
-@ActiveProfiles("test")
-class CountyParserTest {
-    @Autowired
+class CountyParserTest extends AbstractParserTest {
     CountyParser countyParser;
     private ApplicationData applicationData;
 
-    @TestConfiguration
-    @PropertySource(value = "classpath:test-parsing-config.yaml", factory = YamlPropertySourceFactory.class)
-    static class TestPageConfiguration {
-        @SuppressWarnings("ConfigurationProperties")
-        @Bean
-        @ConfigurationProperties(prefix = "test-parsing")
-        public ParsingConfiguration parsingConfiguration() {
-            return new ParsingConfiguration();
-        }
-    }
-
     @BeforeEach
-    void setUp() { applicationData = new ApplicationData(); }
+    void setUp() {
+        applicationData = new ApplicationData();
+        countyParser = new CountyParser(parsingConfiguration, featureFlagConfiguration);
+    }
 
     @Test
     void shouldParseCounty() {

--- a/src/test/java/org/codeforamerica/shiba/application/parsers/CountyParserTest.java
+++ b/src/test/java/org/codeforamerica/shiba/application/parsers/CountyParserTest.java
@@ -21,8 +21,9 @@ import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.NONE;
 
-@SpringBootTest
+@SpringBootTest(webEnvironment = NONE)
 @ActiveProfiles("test")
 @ExtendWith(SpringExtension.class)
 class CountyParserTest {

--- a/src/test/java/org/codeforamerica/shiba/application/parsers/EmailParserTest.java
+++ b/src/test/java/org/codeforamerica/shiba/application/parsers/EmailParserTest.java
@@ -6,7 +6,6 @@ import org.codeforamerica.shiba.pages.data.InputData;
 import org.codeforamerica.shiba.pages.data.PageData;
 import org.codeforamerica.shiba.pages.data.PagesData;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -14,7 +13,6 @@ import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.util.List;
 import java.util.Optional;
@@ -24,8 +22,7 @@ import static org.springframework.boot.test.context.SpringBootTest.WebEnvironmen
 
 @SpringBootTest(webEnvironment = NONE)
 @ActiveProfiles("test")
-@ExtendWith(SpringExtension.class)
-class EmailParserTest{
+class EmailParserTest {
     @Autowired
     EmailParser emailParser;
 

--- a/src/test/java/org/codeforamerica/shiba/application/parsers/EmailParserTest.java
+++ b/src/test/java/org/codeforamerica/shiba/application/parsers/EmailParserTest.java
@@ -1,45 +1,28 @@
 package org.codeforamerica.shiba.application.parsers;
 
-import org.codeforamerica.shiba.YamlPropertySourceFactory;
 import org.codeforamerica.shiba.pages.data.ApplicationData;
 import org.codeforamerica.shiba.pages.data.InputData;
 import org.codeforamerica.shiba.pages.data.PageData;
 import org.codeforamerica.shiba.pages.data.PagesData;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.PropertySource;
-import org.springframework.test.context.ActiveProfiles;
 
 import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.NONE;
 
-@SpringBootTest(webEnvironment = NONE)
-@ActiveProfiles("test")
-class EmailParserTest {
-    @Autowired
+class EmailParserTest extends AbstractParserTest {
     EmailParser emailParser;
-
-    @TestConfiguration
-    @PropertySource(value = "classpath:test-parsing-config.yaml", factory = YamlPropertySourceFactory.class)
-    static class TestPageConfiguration {
-        @Bean
-        @SuppressWarnings("ConfigurationProperties")
-        @ConfigurationProperties(prefix = "test-parsing")
-        public ParsingConfiguration parsingConfiguration() {
-            return new ParsingConfiguration();
-        }
-    }
 
     ApplicationData applicationData = new ApplicationData();
     PagesData pagesData = new PagesData();
     PageData contactInfo = new PageData();
+
+    @BeforeEach
+    void setUp() {
+        emailParser = new EmailParser(parsingConfiguration);
+    }
 
     @Test
     void shouldParseEmail() {

--- a/src/test/java/org/codeforamerica/shiba/application/parsers/EmailParserTest.java
+++ b/src/test/java/org/codeforamerica/shiba/application/parsers/EmailParserTest.java
@@ -20,8 +20,9 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.NONE;
 
-@SpringBootTest
+@SpringBootTest(webEnvironment = NONE)
 @ActiveProfiles("test")
 @ExtendWith(SpringExtension.class)
 class EmailParserTest{

--- a/src/test/java/org/codeforamerica/shiba/application/parsers/EmailParserTest.java
+++ b/src/test/java/org/codeforamerica/shiba/application/parsers/EmailParserTest.java
@@ -21,7 +21,7 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@SpringBootTest(properties = {"spring.main.allow-bean-definition-overriding=true"})
+@SpringBootTest
 @ActiveProfiles("test")
 @ExtendWith(SpringExtension.class)
 class EmailParserTest{

--- a/src/test/java/org/codeforamerica/shiba/application/parsers/HomeAddressParserTest.java
+++ b/src/test/java/org/codeforamerica/shiba/application/parsers/HomeAddressParserTest.java
@@ -20,8 +20,9 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.NONE;
 
-@SpringBootTest
+@SpringBootTest(webEnvironment = NONE)
 @ActiveProfiles("test")
 @ExtendWith(SpringExtension.class)
 class HomeAddressParserTest {

--- a/src/test/java/org/codeforamerica/shiba/application/parsers/HomeAddressParserTest.java
+++ b/src/test/java/org/codeforamerica/shiba/application/parsers/HomeAddressParserTest.java
@@ -21,7 +21,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@SpringBootTest(properties = {"spring.main.allow-bean-definition-overriding=true"})
+@SpringBootTest
 @ActiveProfiles("test")
 @ExtendWith(SpringExtension.class)
 class HomeAddressParserTest {

--- a/src/test/java/org/codeforamerica/shiba/application/parsers/HomeAddressParserTest.java
+++ b/src/test/java/org/codeforamerica/shiba/application/parsers/HomeAddressParserTest.java
@@ -7,7 +7,6 @@ import org.codeforamerica.shiba.pages.data.PageData;
 import org.codeforamerica.shiba.pages.data.PagesData;
 import org.codeforamerica.shiba.pages.enrichment.Address;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -15,7 +14,6 @@ import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.util.List;
 
@@ -24,7 +22,6 @@ import static org.springframework.boot.test.context.SpringBootTest.WebEnvironmen
 
 @SpringBootTest(webEnvironment = NONE)
 @ActiveProfiles("test")
-@ExtendWith(SpringExtension.class)
 class HomeAddressParserTest {
     @Autowired
     HomeAddressParser homeAddressParser;

--- a/src/test/java/org/codeforamerica/shiba/application/parsers/HomeAddressParserTest.java
+++ b/src/test/java/org/codeforamerica/shiba/application/parsers/HomeAddressParserTest.java
@@ -1,44 +1,21 @@
 package org.codeforamerica.shiba.application.parsers;
 
-import org.codeforamerica.shiba.YamlPropertySourceFactory;
 import org.codeforamerica.shiba.pages.data.ApplicationData;
 import org.codeforamerica.shiba.pages.data.InputData;
 import org.codeforamerica.shiba.pages.data.PageData;
 import org.codeforamerica.shiba.pages.data.PagesData;
 import org.codeforamerica.shiba.pages.enrichment.Address;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.PropertySource;
-import org.springframework.test.context.ActiveProfiles;
 
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.NONE;
 
-@SpringBootTest(webEnvironment = NONE)
-@ActiveProfiles("test")
-class HomeAddressParserTest {
-    @Autowired
-    HomeAddressParser homeAddressParser;
-
-    @TestConfiguration
-    @PropertySource(value = "classpath:test-parsing-config.yaml", factory = YamlPropertySourceFactory.class)
-    static class TestPageConfiguration {
-        @SuppressWarnings("ConfigurationProperties")
-        @Bean
-        @ConfigurationProperties(prefix = "test-parsing")
-        public ParsingConfiguration parsingConfiguration() {
-            return new ParsingConfiguration();
-        }
-    }
-
+class HomeAddressParserTest extends AbstractParserTest {
     @Test
     void shouldParseApplicationData() {
+        HomeAddressParser homeAddressParser = new HomeAddressParser(parsingConfiguration);
+
         ApplicationData applicationData = new ApplicationData();
         PagesData pagesData = new PagesData();
         PageData homePageData = new PageData();

--- a/src/test/java/org/codeforamerica/shiba/application/parsers/MailingAddressParserTest.java
+++ b/src/test/java/org/codeforamerica/shiba/application/parsers/MailingAddressParserTest.java
@@ -7,7 +7,6 @@ import org.codeforamerica.shiba.pages.data.PageData;
 import org.codeforamerica.shiba.pages.data.PagesData;
 import org.codeforamerica.shiba.pages.enrichment.Address;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -15,7 +14,6 @@ import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.util.List;
 
@@ -24,7 +22,6 @@ import static org.springframework.boot.test.context.SpringBootTest.WebEnvironmen
 
 @SpringBootTest(webEnvironment = NONE)
 @ActiveProfiles("test")
-@ExtendWith(SpringExtension.class)
 class MailingAddressParserTest {
     @Autowired
     MailingAddressParser mailingAddressParser;

--- a/src/test/java/org/codeforamerica/shiba/application/parsers/MailingAddressParserTest.java
+++ b/src/test/java/org/codeforamerica/shiba/application/parsers/MailingAddressParserTest.java
@@ -1,44 +1,20 @@
 package org.codeforamerica.shiba.application.parsers;
 
-import org.codeforamerica.shiba.YamlPropertySourceFactory;
 import org.codeforamerica.shiba.pages.data.ApplicationData;
 import org.codeforamerica.shiba.pages.data.InputData;
 import org.codeforamerica.shiba.pages.data.PageData;
 import org.codeforamerica.shiba.pages.data.PagesData;
 import org.codeforamerica.shiba.pages.enrichment.Address;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.PropertySource;
-import org.springframework.test.context.ActiveProfiles;
 
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.NONE;
 
-@SpringBootTest(webEnvironment = NONE)
-@ActiveProfiles("test")
-class MailingAddressParserTest {
-    @Autowired
-    MailingAddressParser mailingAddressParser;
-
-    @TestConfiguration
-    @PropertySource(value = "classpath:test-parsing-config.yaml", factory = YamlPropertySourceFactory.class)
-    static class TestPageConfiguration {
-        @SuppressWarnings("ConfigurationProperties")
-        @Bean
-        @ConfigurationProperties(prefix = "test-parsing")
-        public ParsingConfiguration parsingConfiguration() {
-            return new ParsingConfiguration();
-        }
-    }
-
+class MailingAddressParserTest extends AbstractParserTest {
     @Test
     void shouldParseApplicationData() {
+        MailingAddressParser mailingAddressParser = new MailingAddressParser(parsingConfiguration);
         ApplicationData applicationData = new ApplicationData();
         PagesData pagesData = new PagesData();
         PageData homePageData = new PageData();

--- a/src/test/java/org/codeforamerica/shiba/application/parsers/MailingAddressParserTest.java
+++ b/src/test/java/org/codeforamerica/shiba/application/parsers/MailingAddressParserTest.java
@@ -20,8 +20,9 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.NONE;
 
-@SpringBootTest
+@SpringBootTest(webEnvironment = NONE)
 @ActiveProfiles("test")
 @ExtendWith(SpringExtension.class)
 class MailingAddressParserTest {

--- a/src/test/java/org/codeforamerica/shiba/application/parsers/MailingAddressParserTest.java
+++ b/src/test/java/org/codeforamerica/shiba/application/parsers/MailingAddressParserTest.java
@@ -21,7 +21,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@SpringBootTest(properties = {"spring.main.allow-bean-definition-overriding=true"})
+@SpringBootTest
 @ActiveProfiles("test")
 @ExtendWith(SpringExtension.class)
 class MailingAddressParserTest {

--- a/src/test/java/org/codeforamerica/shiba/application/parsers/ParserTestConfiguration.java
+++ b/src/test/java/org/codeforamerica/shiba/application/parsers/ParserTestConfiguration.java
@@ -1,0 +1,18 @@
+package org.codeforamerica.shiba.application.parsers;
+
+import org.codeforamerica.shiba.YamlPropertySourceFactory;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.PropertySource;
+
+@TestConfiguration
+@PropertySource(value = "classpath:test-parsing-config.yaml", factory = YamlPropertySourceFactory.class)
+public class ParserTestConfiguration {
+    @SuppressWarnings("ConfigurationProperties")
+    @Bean
+    @ConfigurationProperties(prefix = "test-parsing")
+    public ParsingConfiguration parsingConfiguration() {
+        return new ParsingConfiguration();
+    }
+}

--- a/src/test/java/org/codeforamerica/shiba/metrics/ApplicationRepositoryTest.java
+++ b/src/test/java/org/codeforamerica/shiba/metrics/ApplicationRepositoryTest.java
@@ -28,8 +28,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.codeforamerica.shiba.County.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.NONE;
 
-@SpringBootTest
+@SpringBootTest(webEnvironment = NONE)
 @ExtendWith(SpringExtension.class)
 @ActiveProfiles("test")
 @Sql(statements = {"ALTER SEQUENCE application_id RESTART WITH 12", "TRUNCATE TABLE applications"})
@@ -181,7 +182,7 @@ class ApplicationRepositoryTest {
     }
 
     @Nested
-    @SpringBootTest
+    @SpringBootTest(webEnvironment = NONE)
     @ExtendWith(SpringExtension.class)
     @ActiveProfiles("test")
     @Sql(statements = {"TRUNCATE TABLE applications"})
@@ -280,7 +281,7 @@ class ApplicationRepositoryTest {
     }
 
     @Nested
-    @SpringBootTest
+    @SpringBootTest(webEnvironment = NONE)
     @ExtendWith(SpringExtension.class)
     @ActiveProfiles("test")
     @Sql(statements = {"TRUNCATE TABLE applications"})

--- a/src/test/java/org/codeforamerica/shiba/metrics/ApplicationRepositoryTest.java
+++ b/src/test/java/org/codeforamerica/shiba/metrics/ApplicationRepositoryTest.java
@@ -8,7 +8,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -16,7 +15,6 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.time.*;
 import java.time.temporal.ChronoUnit;
@@ -31,7 +29,6 @@ import static org.mockito.Mockito.*;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.NONE;
 
 @SpringBootTest(webEnvironment = NONE)
-@ExtendWith(SpringExtension.class)
 @ActiveProfiles("test")
 @Sql(statements = {"ALTER SEQUENCE application_id RESTART WITH 12", "TRUNCATE TABLE applications"})
 @Tag("db")
@@ -183,7 +180,6 @@ class ApplicationRepositoryTest {
 
     @Nested
     @SpringBootTest(webEnvironment = NONE)
-    @ExtendWith(SpringExtension.class)
     @ActiveProfiles("test")
     @Sql(statements = {"TRUNCATE TABLE applications"})
     class EncryptionAndDecryption {
@@ -282,7 +278,6 @@ class ApplicationRepositoryTest {
 
     @Nested
     @SpringBootTest(webEnvironment = NONE)
-    @ExtendWith(SpringExtension.class)
     @ActiveProfiles("test")
     @Sql(statements = {"TRUNCATE TABLE applications"})
     class MetricsQueries {

--- a/src/test/java/org/codeforamerica/shiba/mnit/MnitEsbWebServiceClientTest.java
+++ b/src/test/java/org/codeforamerica/shiba/mnit/MnitEsbWebServiceClientTest.java
@@ -7,13 +7,11 @@ import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.ws.client.WebServiceTransportException;
 import org.springframework.ws.client.core.WebServiceTemplate;
 import org.springframework.ws.soap.client.SoapFaultClientException;
@@ -28,9 +26,7 @@ import javax.xml.transform.dom.DOMResult;
 import java.time.*;
 import java.util.Base64;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
-import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.springframework.ws.test.client.RequestMatchers.connectionTo;
@@ -48,7 +44,6 @@ import static org.springframework.ws.test.client.ResponseCreators.withSoapEnvelo
         "test.counties.Olmsted.dhsProviderId=olmsted-dhs-provider-id"
 })
 @ActiveProfiles("test")
-@ExtendWith(SpringExtension.class)
 class MnitEsbWebServiceClientTest {
     @Autowired
     private WebServiceTemplate webServiceTemplate;
@@ -75,9 +70,9 @@ class MnitEsbWebServiceClientTest {
     String fileName = "fileName";
     StringSource successResponse = new StringSource("" +
             "<SOAP-ENV:Envelope xmlns:SOAP-ENV='http://schemas.xmlsoap.org/soap/envelope/'>" +
-                "<SOAP-ENV:Body xmlns='http://www.cmis.org/2008/05'>" +
-                    "<createDocumentResponse></createDocumentResponse>" +
-                "</SOAP-ENV:Body>" +
+            "<SOAP-ENV:Body xmlns='http://www.cmis.org/2008/05'>" +
+            "<createDocumentResponse></createDocumentResponse>" +
+            "</SOAP-ENV:Body>" +
             "</SOAP-ENV:Envelope>"
     );
 

--- a/src/test/java/org/codeforamerica/shiba/output/MnitDocumentConsumerTest.java
+++ b/src/test/java/org/codeforamerica/shiba/output/MnitDocumentConsumerTest.java
@@ -46,11 +46,11 @@ import static org.codeforamerica.shiba.TestUtils.getAbsoluteFilepath;
 import static org.codeforamerica.shiba.output.Document.*;
 import static org.codeforamerica.shiba.output.Recipient.CASEWORKER;
 import static org.mockito.Mockito.*;
-import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.NONE;
 
 @ExtendWith(SpringExtension.class)
 @ActiveProfiles("test")
-@SpringBootTest(webEnvironment = RANDOM_PORT)
+@SpringBootTest(webEnvironment = NONE)
 @Tag("db")
 class MnitDocumentConsumerTest {
     @TestConfiguration

--- a/src/test/java/org/codeforamerica/shiba/output/MnitDocumentConsumerTest.java
+++ b/src/test/java/org/codeforamerica/shiba/output/MnitDocumentConsumerTest.java
@@ -20,7 +20,6 @@ import org.codeforamerica.shiba.pages.data.PagesData;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -32,7 +31,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -48,7 +46,6 @@ import static org.codeforamerica.shiba.output.Recipient.CASEWORKER;
 import static org.mockito.Mockito.*;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.NONE;
 
-@ExtendWith(SpringExtension.class)
 @ActiveProfiles("test")
 @SpringBootTest(webEnvironment = NONE)
 @Tag("db")

--- a/src/test/java/org/codeforamerica/shiba/output/MnitDocumentConsumerTest.java
+++ b/src/test/java/org/codeforamerica/shiba/output/MnitDocumentConsumerTest.java
@@ -50,9 +50,7 @@ import static org.springframework.boot.test.context.SpringBootTest.WebEnvironmen
 
 @ExtendWith(SpringExtension.class)
 @ActiveProfiles("test")
-@SpringBootTest(webEnvironment = RANDOM_PORT, properties = {
-        "spring.main.allow-bean-definition-overriding=true"
-})
+@SpringBootTest(webEnvironment = RANDOM_PORT)
 @Tag("db")
 class MnitDocumentConsumerTest {
     @TestConfiguration

--- a/src/test/java/org/codeforamerica/shiba/output/MnitDocumentConsumerTest.java
+++ b/src/test/java/org/codeforamerica/shiba/output/MnitDocumentConsumerTest.java
@@ -1,10 +1,7 @@
 package org.codeforamerica.shiba.output;
 
 import de.redsix.pdfcompare.PdfComparator;
-import org.codeforamerica.shiba.County;
-import org.codeforamerica.shiba.MonitoringService;
-import org.codeforamerica.shiba.PageDataBuilder;
-import org.codeforamerica.shiba.PagesDataBuilder;
+import org.codeforamerica.shiba.*;
 import org.codeforamerica.shiba.application.Application;
 import org.codeforamerica.shiba.application.ApplicationRepository;
 import org.codeforamerica.shiba.application.parsers.DocumentListParser;
@@ -23,14 +20,13 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.context.MessageSource;
-import org.springframework.context.annotation.Bean;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -48,16 +44,9 @@ import static org.springframework.boot.test.context.SpringBootTest.WebEnvironmen
 
 @ActiveProfiles("test")
 @SpringBootTest(webEnvironment = NONE)
+@ContextConfiguration(classes = {NonSessionScopedApplicationData.class})
 @Tag("db")
 class MnitDocumentConsumerTest {
-    @TestConfiguration
-    static class NonSessionScopedApplicationData {
-        @Bean
-        public ApplicationData applicationData() {
-            return new ApplicationData();
-        }
-    }
-
     @MockBean
     private MnitEsbWebServiceClient mnitClient;
     @MockBean

--- a/src/test/java/org/codeforamerica/shiba/output/TotalIncomeParserTest.java
+++ b/src/test/java/org/codeforamerica/shiba/output/TotalIncomeParserTest.java
@@ -9,7 +9,6 @@ import org.codeforamerica.shiba.output.caf.TotalIncome;
 import org.codeforamerica.shiba.pages.data.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -18,7 +17,6 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.util.List;
 import java.util.Map;
@@ -31,7 +29,6 @@ import static org.springframework.boot.test.context.SpringBootTest.WebEnvironmen
 
 @SpringBootTest(webEnvironment = NONE)
 @ActiveProfiles("test")
-@ExtendWith(SpringExtension.class)
 class TotalIncomeParserTest {
     private final ApplicationData applicationData = new ApplicationData();
     private final PagesData pagesData = new PagesData();

--- a/src/test/java/org/codeforamerica/shiba/output/TotalIncomeParserTest.java
+++ b/src/test/java/org/codeforamerica/shiba/output/TotalIncomeParserTest.java
@@ -28,7 +28,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-@SpringBootTest(properties = {"spring.main.allow-bean-definition-overriding=true"})
+@SpringBootTest
 @ActiveProfiles("test")
 @ExtendWith(SpringExtension.class)
 class TotalIncomeParserTest {

--- a/src/test/java/org/codeforamerica/shiba/output/TotalIncomeParserTest.java
+++ b/src/test/java/org/codeforamerica/shiba/output/TotalIncomeParserTest.java
@@ -27,8 +27,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.NONE;
 
-@SpringBootTest
+@SpringBootTest(webEnvironment = NONE)
 @ActiveProfiles("test")
 @ExtendWith(SpringExtension.class)
 class TotalIncomeParserTest {

--- a/src/test/java/org/codeforamerica/shiba/output/applicationinputsmappers/DerivedValueApplicationInputsMapperTest.java
+++ b/src/test/java/org/codeforamerica/shiba/output/applicationinputsmappers/DerivedValueApplicationInputsMapperTest.java
@@ -25,7 +25,7 @@ import java.util.Map;
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 
-@SpringBootTest(properties = {"spring.main.allow-bean-definition-overriding=true"})
+@SpringBootTest
 @ActiveProfiles("test")
 class DerivedValueApplicationInputsMapperTest {
 

--- a/src/test/java/org/codeforamerica/shiba/output/applicationinputsmappers/DerivedValueApplicationInputsMapperTest.java
+++ b/src/test/java/org/codeforamerica/shiba/output/applicationinputsmappers/DerivedValueApplicationInputsMapperTest.java
@@ -24,8 +24,9 @@ import java.util.Map;
 
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.NONE;
 
-@SpringBootTest
+@SpringBootTest(webEnvironment = NONE)
 @ActiveProfiles("test")
 class DerivedValueApplicationInputsMapperTest {
 

--- a/src/test/java/org/codeforamerica/shiba/output/caf/CcapExpeditedEligibilityParserTest.java
+++ b/src/test/java/org/codeforamerica/shiba/output/caf/CcapExpeditedEligibilityParserTest.java
@@ -19,8 +19,9 @@ import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.NONE;
 
-@SpringBootTest
+@SpringBootTest(webEnvironment = NONE)
 @ActiveProfiles("test")
 @ExtendWith(SpringExtension.class)
 class CcapExpeditedEligibilityParserTest {

--- a/src/test/java/org/codeforamerica/shiba/output/caf/CcapExpeditedEligibilityParserTest.java
+++ b/src/test/java/org/codeforamerica/shiba/output/caf/CcapExpeditedEligibilityParserTest.java
@@ -2,10 +2,12 @@ package org.codeforamerica.shiba.output.caf;
 
 import org.codeforamerica.shiba.YamlPropertySourceFactory;
 import org.codeforamerica.shiba.application.parsers.ParsingConfiguration;
-import org.codeforamerica.shiba.pages.data.*;
+import org.codeforamerica.shiba.pages.data.ApplicationData;
+import org.codeforamerica.shiba.pages.data.InputData;
+import org.codeforamerica.shiba.pages.data.PageData;
+import org.codeforamerica.shiba.pages.data.PagesData;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -13,7 +15,6 @@ import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.util.List;
 import java.util.Map;
@@ -23,7 +24,6 @@ import static org.springframework.boot.test.context.SpringBootTest.WebEnvironmen
 
 @SpringBootTest(webEnvironment = NONE)
 @ActiveProfiles("test")
-@ExtendWith(SpringExtension.class)
 class CcapExpeditedEligibilityParserTest {
     @Autowired
     CcapExpeditedEligibilityParser ccapExpeditedEligibilityParser;

--- a/src/test/java/org/codeforamerica/shiba/output/caf/CcapExpeditedEligibilityParserTest.java
+++ b/src/test/java/org/codeforamerica/shiba/output/caf/CcapExpeditedEligibilityParserTest.java
@@ -20,7 +20,7 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@SpringBootTest(properties = {"spring.main.allow-bean-definition-overriding=true"})
+@SpringBootTest
 @ActiveProfiles("test")
 @ExtendWith(SpringExtension.class)
 class CcapExpeditedEligibilityParserTest {

--- a/src/test/java/org/codeforamerica/shiba/output/caf/GrossMonthlyIncomeParserTest.java
+++ b/src/test/java/org/codeforamerica/shiba/output/caf/GrossMonthlyIncomeParserTest.java
@@ -7,7 +7,6 @@ import org.codeforamerica.shiba.application.parsers.GrossMonthlyIncomeParser;
 import org.codeforamerica.shiba.application.parsers.ParsingConfiguration;
 import org.codeforamerica.shiba.pages.data.*;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -15,7 +14,6 @@ import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.util.List;
 import java.util.Map;
@@ -25,7 +23,6 @@ import static org.springframework.boot.test.context.SpringBootTest.WebEnvironmen
 
 @SpringBootTest(webEnvironment = NONE)
 @ActiveProfiles("test")
-@ExtendWith(SpringExtension.class)
 class GrossMonthlyIncomeParserTest {
     private final ApplicationData applicationData = new ApplicationData();
 

--- a/src/test/java/org/codeforamerica/shiba/output/caf/GrossMonthlyIncomeParserTest.java
+++ b/src/test/java/org/codeforamerica/shiba/output/caf/GrossMonthlyIncomeParserTest.java
@@ -22,7 +22,7 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@SpringBootTest(properties = {"spring.main.allow-bean-definition-overriding=true"})
+@SpringBootTest
 @ActiveProfiles("test")
 @ExtendWith(SpringExtension.class)
 class GrossMonthlyIncomeParserTest {

--- a/src/test/java/org/codeforamerica/shiba/output/caf/GrossMonthlyIncomeParserTest.java
+++ b/src/test/java/org/codeforamerica/shiba/output/caf/GrossMonthlyIncomeParserTest.java
@@ -21,8 +21,9 @@ import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.NONE;
 
-@SpringBootTest
+@SpringBootTest(webEnvironment = NONE)
 @ActiveProfiles("test")
 @ExtendWith(SpringExtension.class)
 class GrossMonthlyIncomeParserTest {

--- a/src/test/java/org/codeforamerica/shiba/output/caf/SnapExpeditedEligibilityParserTest.java
+++ b/src/test/java/org/codeforamerica/shiba/output/caf/SnapExpeditedEligibilityParserTest.java
@@ -30,7 +30,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-@SpringBootTest(properties = {"spring.main.allow-bean-definition-overriding=true"})
+@SpringBootTest
 @ActiveProfiles("test")
 @ExtendWith(SpringExtension.class)
 class SnapExpeditedEligibilityParserTest {

--- a/src/test/java/org/codeforamerica/shiba/output/caf/SnapExpeditedEligibilityParserTest.java
+++ b/src/test/java/org/codeforamerica/shiba/output/caf/SnapExpeditedEligibilityParserTest.java
@@ -2,15 +2,14 @@ package org.codeforamerica.shiba.output.caf;
 
 import org.codeforamerica.shiba.YamlPropertySourceFactory;
 import org.codeforamerica.shiba.application.parsers.ApplicationDataParser;
-import org.codeforamerica.shiba.application.parsers.SnapExpeditedEligibilityParser;
 import org.codeforamerica.shiba.application.parsers.ParsingConfiguration;
+import org.codeforamerica.shiba.application.parsers.SnapExpeditedEligibilityParser;
 import org.codeforamerica.shiba.pages.data.ApplicationData;
 import org.codeforamerica.shiba.pages.data.InputData;
 import org.codeforamerica.shiba.pages.data.PageData;
 import org.codeforamerica.shiba.pages.data.PagesData;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -19,7 +18,6 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.util.List;
 import java.util.Map;
@@ -33,7 +31,6 @@ import static org.springframework.boot.test.context.SpringBootTest.WebEnvironmen
 
 @SpringBootTest(webEnvironment = NONE)
 @ActiveProfiles("test")
-@ExtendWith(SpringExtension.class)
 class SnapExpeditedEligibilityParserTest {
     @Autowired
     SnapExpeditedEligibilityParser snapExpeditedEligibilityParser;

--- a/src/test/java/org/codeforamerica/shiba/output/caf/SnapExpeditedEligibilityParserTest.java
+++ b/src/test/java/org/codeforamerica/shiba/output/caf/SnapExpeditedEligibilityParserTest.java
@@ -29,8 +29,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.NONE;
 
-@SpringBootTest
+@SpringBootTest(webEnvironment = NONE)
 @ActiveProfiles("test")
 @ExtendWith(SpringExtension.class)
 class SnapExpeditedEligibilityParserTest {

--- a/src/test/java/org/codeforamerica/shiba/output/xml/XmlGeneratorIntegrationTest.java
+++ b/src/test/java/org/codeforamerica/shiba/output/xml/XmlGeneratorIntegrationTest.java
@@ -43,8 +43,9 @@ import java.util.stream.Collectors;
 import static java.util.stream.Collectors.toMap;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.codeforamerica.shiba.output.Recipient.CASEWORKER;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.NONE;
 
-@SpringBootTest
+@SpringBootTest(webEnvironment = NONE)
 @ActiveProfiles("test")
 @ExtendWith(SpringExtension.class)
 public class XmlGeneratorIntegrationTest {

--- a/src/test/java/org/codeforamerica/shiba/output/xml/XmlGeneratorIntegrationTest.java
+++ b/src/test/java/org/codeforamerica/shiba/output/xml/XmlGeneratorIntegrationTest.java
@@ -14,13 +14,11 @@ import org.codeforamerica.shiba.pages.data.PageData;
 import org.codeforamerica.shiba.pages.data.PagesData;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.core.io.Resource;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.w3c.dom.Node;
 import org.xml.sax.SAXException;
 
@@ -47,7 +45,6 @@ import static org.springframework.boot.test.context.SpringBootTest.WebEnvironmen
 
 @SpringBootTest(webEnvironment = NONE)
 @ActiveProfiles("test")
-@ExtendWith(SpringExtension.class)
 public class XmlGeneratorIntegrationTest {
     @Autowired
     private FileGenerator xmlGenerator;

--- a/src/test/java/org/codeforamerica/shiba/pages/ConditionalInputsPageTest.java
+++ b/src/test/java/org/codeforamerica/shiba/pages/ConditionalInputsPageTest.java
@@ -12,10 +12,7 @@ import java.util.Locale;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 
-@SpringBootTest(webEnvironment = RANDOM_PORT, properties = {
-        "spring.main.allow-bean-definition-overriding=true",
-        "pagesConfig=pages-config/test-conditional-inputs.yaml"
-})
+@SpringBootTest(webEnvironment = RANDOM_PORT, properties = {"pagesConfig=pages-config/test-conditional-inputs.yaml"})
 public class ConditionalInputsPageTest extends AbstractExistingStartTimePageTest {
 
     @Override

--- a/src/test/java/org/codeforamerica/shiba/pages/ConditionalRenderingPageTest.java
+++ b/src/test/java/org/codeforamerica/shiba/pages/ConditionalRenderingPageTest.java
@@ -13,10 +13,7 @@ import java.util.Locale;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 
-@SpringBootTest(webEnvironment = RANDOM_PORT, properties = {
-        "spring.main.allow-bean-definition-overriding=true",
-        "pagesConfig=pages-config/test-conditional-rendering.yaml"
-})
+@SpringBootTest(webEnvironment = RANDOM_PORT, properties = {"pagesConfig=pages-config/test-conditional-rendering.yaml"})
 public class ConditionalRenderingPageTest extends AbstractExistingStartTimePageTest {
 
     private final String fourthPageTitle = "fourthPageTitle";

--- a/src/test/java/org/codeforamerica/shiba/pages/EnrichmentPageTest.java
+++ b/src/test/java/org/codeforamerica/shiba/pages/EnrichmentPageTest.java
@@ -20,10 +20,7 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 
-@SpringBootTest(webEnvironment = RANDOM_PORT, properties = {
-        "spring.main.allow-bean-definition-overriding=true",
-        "pagesConfig=pages-config/test-enrichment.yaml"
-})
+@SpringBootTest(webEnvironment = RANDOM_PORT, properties = {"pagesConfig=pages-config/test-enrichment.yaml"})
 @ContextConfiguration(classes = EnrichmentPageTest.TestBeans.class)
 public class EnrichmentPageTest extends AbstractExistingStartTimePageTest {
 

--- a/src/test/java/org/codeforamerica/shiba/pages/FeatureFlagPageTest.java
+++ b/src/test/java/org/codeforamerica/shiba/pages/FeatureFlagPageTest.java
@@ -12,10 +12,7 @@ import java.util.Locale;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 
-@SpringBootTest(webEnvironment = RANDOM_PORT, properties = {
-        "spring.main.allow-bean-definition-overriding=true",
-        "pagesConfig=pages-config/test-feature-flag.yaml"
-})
+@SpringBootTest(webEnvironment = RANDOM_PORT, properties = {"pagesConfig=pages-config/test-feature-flag.yaml"})
 public class FeatureFlagPageTest extends AbstractExistingStartTimePageTest {
 
     @Override

--- a/src/test/java/org/codeforamerica/shiba/pages/InputsPageTest.java
+++ b/src/test/java/org/codeforamerica/shiba/pages/InputsPageTest.java
@@ -16,10 +16,7 @@ import java.util.Locale;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 
-@SpringBootTest(webEnvironment = RANDOM_PORT, properties = {
-        "spring.main.allow-bean-definition-overriding=true",
-        "pagesConfig=pages-config/test-input.yaml"
-})
+@SpringBootTest(webEnvironment = RANDOM_PORT, properties = {"pagesConfig=pages-config/test-input.yaml"})
 public class InputsPageTest extends AbstractExistingStartTimePageTest {
 
     String radioOption1 = "radio option 1";

--- a/src/test/java/org/codeforamerica/shiba/pages/LandmarkPageTest.java
+++ b/src/test/java/org/codeforamerica/shiba/pages/LandmarkPageTest.java
@@ -19,10 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 
 @Import(LandmarkPageTest.TestController.class)
-@SpringBootTest(webEnvironment = RANDOM_PORT, properties = {
-        "spring.main.allow-bean-definition-overriding=true",
-        "pagesConfig=pages-config/test-landmark-pages.yaml"
-})
+@SpringBootTest(webEnvironment = RANDOM_PORT, properties = {"pagesConfig=pages-config/test-landmark-pages.yaml"})
 public class LandmarkPageTest extends AbstractStaticMessageSourcePageTest {
     String firstPageTitle = "first page title";
     String fourthPageTitle = "fourth page title";

--- a/src/test/java/org/codeforamerica/shiba/pages/PageControllerTest.java
+++ b/src/test/java/org/codeforamerica/shiba/pages/PageControllerTest.java
@@ -46,10 +46,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @ActiveProfiles("test")
 @ExtendWith(SpringExtension.class)
-@SpringBootTest(webEnvironment = RANDOM_PORT, properties = {
-        "spring.main.allow-bean-definition-overriding=true",
-        "pagesConfig=pages-config/test-pages-controller.yaml"
-})
+@SpringBootTest(webEnvironment = RANDOM_PORT, properties = {"pagesConfig=pages-config/test-pages-controller.yaml"})
 class PageControllerTest {
     @TestConfiguration
     static class NonSessionScopedApplicationData {

--- a/src/test/java/org/codeforamerica/shiba/pages/PageControllerTest.java
+++ b/src/test/java/org/codeforamerica/shiba/pages/PageControllerTest.java
@@ -1,5 +1,6 @@
 package org.codeforamerica.shiba.pages;
 
+import org.codeforamerica.shiba.NonSessionScopedApplicationData;
 import org.codeforamerica.shiba.UploadDocumentConfiguration;
 import org.codeforamerica.shiba.application.Application;
 import org.codeforamerica.shiba.application.ApplicationFactory;
@@ -20,14 +21,13 @@ import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.MessageSource;
-import org.springframework.context.annotation.Bean;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpSession;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
@@ -44,15 +44,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @ActiveProfiles("test")
 @SpringBootTest(webEnvironment = MOCK, properties = {"pagesConfig=pages-config/test-pages-controller.yaml"})
+@ContextConfiguration(classes = {NonSessionScopedApplicationData.class})
 class PageControllerTest {
-    @TestConfiguration
-    static class NonSessionScopedApplicationData {
-        @Bean
-        public ApplicationData applicationData() {
-            return new ApplicationData();
-        }
-    }
-
     @MockBean
     private MessageSource messageSource;
     private MockMvc mockMvc;

--- a/src/test/java/org/codeforamerica/shiba/pages/PageControllerTest.java
+++ b/src/test/java/org/codeforamerica/shiba/pages/PageControllerTest.java
@@ -39,14 +39,14 @@ import java.util.Locale;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Mockito.*;
-import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.MOCK;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.flash;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
 
 @ActiveProfiles("test")
 @ExtendWith(SpringExtension.class)
-@SpringBootTest(webEnvironment = RANDOM_PORT, properties = {"pagesConfig=pages-config/test-pages-controller.yaml"})
+@SpringBootTest(webEnvironment = MOCK, properties = {"pagesConfig=pages-config/test-pages-controller.yaml"})
 class PageControllerTest {
     @TestConfiguration
     static class NonSessionScopedApplicationData {

--- a/src/test/java/org/codeforamerica/shiba/pages/PageControllerTest.java
+++ b/src/test/java/org/codeforamerica/shiba/pages/PageControllerTest.java
@@ -17,7 +17,6 @@ import org.codeforamerica.shiba.pages.events.PageEventPublisher;
 import org.codeforamerica.shiba.pages.events.UploadedDocumentsSubmittedEvent;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InOrder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -29,7 +28,6 @@ import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpSession;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
@@ -45,7 +43,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
 
 @ActiveProfiles("test")
-@ExtendWith(SpringExtension.class)
 @SpringBootTest(webEnvironment = MOCK, properties = {"pagesConfig=pages-config/test-pages-controller.yaml"})
 class PageControllerTest {
     @TestConfiguration

--- a/src/test/java/org/codeforamerica/shiba/pages/PageDatasourcePageTest.java
+++ b/src/test/java/org/codeforamerica/shiba/pages/PageDatasourcePageTest.java
@@ -14,10 +14,7 @@ import java.util.Locale;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 
-@SpringBootTest(webEnvironment = RANDOM_PORT, properties = {
-        "spring.main.allow-bean-definition-overriding=true",
-        "pagesConfig=pages-config/test-page-datasources.yaml"
-})
+@SpringBootTest(webEnvironment = RANDOM_PORT, properties = {"pagesConfig=pages-config/test-page-datasources.yaml"})
 public class PageDatasourcePageTest extends AbstractExistingStartTimePageTest {
     private final String staticPageWithDatasourceInputsTitle = "staticPageWithDatasourceInputsTitle";
     private final String yesHeaderText = "yes header text";

--- a/src/test/java/org/codeforamerica/shiba/pages/PageModelPageTest.java
+++ b/src/test/java/org/codeforamerica/shiba/pages/PageModelPageTest.java
@@ -12,7 +12,6 @@ import static org.springframework.boot.test.context.SpringBootTest.WebEnvironmen
 
 @SpringBootTest(webEnvironment = RANDOM_PORT, properties = {"pagesConfig=pages-config/test-page-model.yaml"})
 public class PageModelPageTest extends AbstractExistingStartTimePageTest {
-
     String title;
     String subtleLink;
     String subtleLinkTitle;

--- a/src/test/java/org/codeforamerica/shiba/pages/PageModelPageTest.java
+++ b/src/test/java/org/codeforamerica/shiba/pages/PageModelPageTest.java
@@ -10,10 +10,7 @@ import java.util.Locale;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 
-@SpringBootTest(webEnvironment = RANDOM_PORT, properties = {
-        "spring.main.allow-bean-definition-overriding=true",
-        "pagesConfig=pages-config/test-page-model.yaml"
-})
+@SpringBootTest(webEnvironment = RANDOM_PORT, properties = {"pagesConfig=pages-config/test-page-model.yaml"})
 public class PageModelPageTest extends AbstractExistingStartTimePageTest {
 
     String title;

--- a/src/test/java/org/codeforamerica/shiba/pages/StartTimerPageTest.java
+++ b/src/test/java/org/codeforamerica/shiba/pages/StartTimerPageTest.java
@@ -19,10 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 
 @Import(StartTimerPageTest.TestController.class)
-@SpringBootTest(webEnvironment = RANDOM_PORT, properties = {
-        "spring.main.allow-bean-definition-overriding=true",
-        "pagesConfig=pages-config/test-start-timer.yaml"
-})
+@SpringBootTest(webEnvironment = RANDOM_PORT, properties = {"pagesConfig=pages-config/test-start-timer.yaml"})
 public class StartTimerPageTest extends AbstractStaticMessageSourcePageTest {
     @Controller
     static class TestController {

--- a/src/test/java/org/codeforamerica/shiba/pages/SubWorkflowPageTest.java
+++ b/src/test/java/org/codeforamerica/shiba/pages/SubWorkflowPageTest.java
@@ -18,10 +18,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 
-@SpringBootTest(webEnvironment = RANDOM_PORT, properties = {
-        "spring.main.allow-bean-definition-overriding=true",
-        "pagesConfig=pages-config/test-sub-workflow.yaml"
-})
+@SpringBootTest(webEnvironment = RANDOM_PORT, properties = {"pagesConfig=pages-config/test-sub-workflow.yaml"})
 public class SubWorkflowPageTest extends AbstractExistingStartTimePageTest {
 
     @MockBean

--- a/src/test/java/org/codeforamerica/shiba/pages/SubWorkflowPageTest.java
+++ b/src/test/java/org/codeforamerica/shiba/pages/SubWorkflowPageTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
 
 import java.io.IOException;
 import java.util.Locale;
@@ -19,6 +20,7 @@ import static org.mockito.Mockito.verify;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 
 @SpringBootTest(webEnvironment = RANDOM_PORT, properties = {"pagesConfig=pages-config/test-sub-workflow.yaml"})
+@ActiveProfiles("test")
 public class SubWorkflowPageTest extends AbstractExistingStartTimePageTest {
 
     @MockBean

--- a/src/test/java/org/codeforamerica/shiba/pages/SubmitPageTest.java
+++ b/src/test/java/org/codeforamerica/shiba/pages/SubmitPageTest.java
@@ -28,10 +28,7 @@ import static org.mockito.Mockito.when;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 
 @Sql(statements = {"TRUNCATE TABLE applications"})
-@SpringBootTest(webEnvironment = RANDOM_PORT, properties = {
-        "spring.main.allow-bean-definition-overriding=true",
-        "pagesConfig=pages-config/test-submit-page.yaml"
-})
+@SpringBootTest(webEnvironment = RANDOM_PORT, properties = {"pagesConfig=pages-config/test-submit-page.yaml"})
 @Tag("db")
 public class SubmitPageTest extends AbstractStaticMessageSourcePageTest {
 

--- a/src/test/java/org/codeforamerica/shiba/pages/UserDecisionNavigationPageTest.java
+++ b/src/test/java/org/codeforamerica/shiba/pages/UserDecisionNavigationPageTest.java
@@ -19,10 +19,7 @@ import static org.codeforamerica.shiba.pages.YesNoAnswer.YES;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 
 @Import(UserDecisionNavigationPageTest.TestController.class)
-@SpringBootTest(webEnvironment = RANDOM_PORT, properties = {
-        "spring.main.allow-bean-definition-overriding=true",
-        "pagesConfig=pages-config/test-user-decision-navigation.yaml"
-})
+@SpringBootTest(webEnvironment = RANDOM_PORT, properties = {"pagesConfig=pages-config/test-user-decision-navigation.yaml"})
 public class UserDecisionNavigationPageTest extends AbstractExistingStartTimePageTest {
 
     private final String optionZeroPageTitle = "page zero title";

--- a/src/test/java/org/codeforamerica/shiba/pages/ValidationPageTest.java
+++ b/src/test/java/org/codeforamerica/shiba/pages/ValidationPageTest.java
@@ -17,10 +17,7 @@ import java.util.Locale;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 
-@SpringBootTest(webEnvironment = RANDOM_PORT, properties = {
-        "spring.main.allow-bean-definition-overriding=true",
-        "pagesConfig=pages-config/test-validation.yaml"
-})
+@SpringBootTest(webEnvironment = RANDOM_PORT, properties = {"pagesConfig=pages-config/test-validation.yaml"})
 public class ValidationPageTest extends AbstractExistingStartTimePageTest {
 
     private final String errorMessage = "error message";

--- a/src/test/java/org/codeforamerica/shiba/pages/YesNoAnswerPageTest.java
+++ b/src/test/java/org/codeforamerica/shiba/pages/YesNoAnswerPageTest.java
@@ -12,10 +12,7 @@ import java.util.Locale;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 
-@SpringBootTest(webEnvironment = RANDOM_PORT, properties = {
-        "spring.main.allow-bean-definition-overriding=true",
-        "pagesConfig=pages-config/yes-no-answer.yaml"
-})
+@SpringBootTest(webEnvironment = RANDOM_PORT, properties = {"pagesConfig=pages-config/yes-no-answer.yaml"})
 public class YesNoAnswerPageTest extends AbstractExistingStartTimePageTest {
 
     private final String answerPage = "option-zero-page-title";

--- a/src/test/java/org/codeforamerica/shiba/pages/data/ApplicationDataSerializationTest.java
+++ b/src/test/java/org/codeforamerica/shiba/pages/data/ApplicationDataSerializationTest.java
@@ -34,9 +34,7 @@ import static org.mockito.Mockito.when;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.NONE;
 
 @ExtendWith(SpringExtension.class)
-@SpringBootTest(webEnvironment = NONE, properties = {
-        "spring.main.allow-bean-definition-overriding=true"
-})
+@SpringBootTest(webEnvironment = NONE)
 @ActiveProfiles("test")
 class ApplicationDataSerializationTest {
 

--- a/src/test/java/org/codeforamerica/shiba/pages/data/ApplicationDataSerializationTest.java
+++ b/src/test/java/org/codeforamerica/shiba/pages/data/ApplicationDataSerializationTest.java
@@ -7,12 +7,10 @@ import org.codeforamerica.shiba.output.caf.FileNameGenerator;
 import org.codeforamerica.shiba.output.pdf.PdfGenerator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -33,7 +31,6 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.NONE;
 
-@ExtendWith(SpringExtension.class)
 @SpringBootTest(webEnvironment = NONE)
 @ActiveProfiles("test")
 class ApplicationDataSerializationTest {

--- a/src/test/java/org/codeforamerica/shiba/pages/emails/MailGunEmailClientTest.java
+++ b/src/test/java/org/codeforamerica/shiba/pages/emails/MailGunEmailClientTest.java
@@ -36,8 +36,9 @@ import static org.codeforamerica.shiba.output.caf.SnapExpeditedEligibility.ELIGI
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.*;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.NONE;
 
-@SpringBootTest
+@SpringBootTest(webEnvironment = NONE)
 @ActiveProfiles("test")
 @ExtendWith(SpringExtension.class)
 class MailGunEmailClientTest {

--- a/src/test/java/org/codeforamerica/shiba/pages/emails/MailGunEmailClientTest.java
+++ b/src/test/java/org/codeforamerica/shiba/pages/emails/MailGunEmailClientTest.java
@@ -15,14 +15,12 @@ import org.codeforamerica.shiba.pages.data.ApplicationData;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.time.ZonedDateTime;
 import java.util.List;
@@ -40,7 +38,6 @@ import static org.springframework.boot.test.context.SpringBootTest.WebEnvironmen
 
 @SpringBootTest(webEnvironment = NONE)
 @ActiveProfiles("test")
-@ExtendWith(SpringExtension.class)
 class MailGunEmailClientTest {
 
     MailGunEmailClient mailGunEmailClient;

--- a/src/test/java/org/codeforamerica/shiba/pages/enrichment/smartstreets/SmartyStreetClientTest.java
+++ b/src/test/java/org/codeforamerica/shiba/pages/enrichment/smartstreets/SmartyStreetClientTest.java
@@ -22,8 +22,9 @@ import java.util.Optional;
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.NONE;
 
-@SpringBootTest
+@SpringBootTest(webEnvironment = NONE)
 @ActiveProfiles("test")
 @ExtendWith(SpringExtension.class)
 class SmartyStreetClientTest {

--- a/src/test/java/org/codeforamerica/shiba/pages/enrichment/smartstreets/SmartyStreetClientTest.java
+++ b/src/test/java/org/codeforamerica/shiba/pages/enrichment/smartstreets/SmartyStreetClientTest.java
@@ -11,10 +11,8 @@ import org.codeforamerica.shiba.pages.enrichment.smartystreets.SmartyStreetClien
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.util.Map;
 import java.util.Optional;
@@ -26,7 +24,6 @@ import static org.springframework.boot.test.context.SpringBootTest.WebEnvironmen
 
 @SpringBootTest(webEnvironment = NONE)
 @ActiveProfiles("test")
-@ExtendWith(SpringExtension.class)
 class SmartyStreetClientTest {
     SmartyStreetClient smartyStreetClient;
 

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -5,6 +5,8 @@ spring:
     password: sa
   flyway:
     enabled: false
+  main:
+    allow-bean-definition-overriding: true
 
 client:
   keystore: src/test/resources/test-keystore.jks


### PR DESCRIPTION
- Try to reduce boilerplate/noise in individual test files by moving `allow-bean-definition-overriding` to `application-test.yaml`
- Stop creating a real webenvironment for tests that don't need it.
- Remove all occurrences of `@ExtendWith(SpringExtension.class)` (it's included in `@SpringBootTest`)
- Introduce `AbstractRepositoryTest` for repositories so they don't have to use SpringBootTest. (This shaved about 20s off of the dbTest task)
- Introduce `AbstractParserTest` that only spins up configuration necessary for parser tests
- IMPROVE OUR LOGGING IN CI!!!!