### PR TITLE
Run db tests and unit test jobs in parallel; stop spinning up postgres for tests

### DIFF
--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -11,52 +11,48 @@ on:
     inputs: { }
 
 jobs:
-  test:
-    name: Run test suite
+  unit-test:
+    name: Run unit tests
     runs-on: ubuntu-latest
-    services:
-      postgres:
-        image: postgres:12
-        env:
-          POSTGRES_USER: shiba
-          POSTGRES_PASSWORD: shiba
-          POSTGRES_DB: shiba-test
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        ports:
-          - 5432:5432
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up ChromeDriver
-      uses: nanasess/setup-chromedriver@v1.0.1
-    - name: Set up JDK
-      uses: actions/setup-java@v1
-      with:
-        java-version: '14'
-    - name: Grant execute permission for gradlew
-      run: chmod +x gradlew
-    - name: Test with Gradle
-      run: ./gradlew clean testAll
-      env:
-        S3_BUCKET: ${{ secrets.S3_STAGING_BUCKET }}
-        AWS_ACCESS_KEY: ${{ secrets.CLOUD_AWS_CREDENTIALS_ACCESS_KEY }}
-        AWS_SECRET_KEY: ${{ secrets.CLOUD_AWS_CREDENTIALS_SECRET_KEY }}
-    - name: Announce test failure on slack
-      if: ${{ failure() }}
-      uses: innocarpe/actions-slack@v1
-      with:
-        status: ${{ job.status }}
-        failure_text: 'Tests failed in CI! :disappointed:'
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
+      - uses: actions/checkout@v2
+      - name: Set up ChromeDriver
+        uses: nanasess/setup-chromedriver@v1.0.1
+      - name: Set up JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: '14'
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+      - name: Test with Gradle
+        run: ./gradlew unitTest
+        env:
+          S3_BUCKET: ${{ secrets.S3_TEST_BUCKET }}
+          AWS_ACCESS_KEY: ${{ secrets.CLOUD_AWS_CREDENTIALS_ACCESS_KEY }}
+          AWS_SECRET_KEY: ${{ secrets.CLOUD_AWS_CREDENTIALS_SECRET_KEY }}
+  db-test:
+    name: Run db tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up ChromeDriver
+        uses: nanasess/setup-chromedriver@v1.0.1
+      - name: Set up JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: '14'
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+      - name: Test with Gradle
+        run: ./gradlew dbTest
+        env:
+          S3_BUCKET: ${{ secrets.S3_TEST_BUCKET }}
+          AWS_ACCESS_KEY: ${{ secrets.CLOUD_AWS_CREDENTIALS_ACCESS_KEY }}
+          AWS_SECRET_KEY: ${{ secrets.CLOUD_AWS_CREDENTIALS_SECRET_KEY }}
   deploy:
     name: Deploy to Aptible staging
     runs-on: ubuntu-latest
-    needs: test
+    needs: [unit-test, db-test]
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/run-tests-on-pr.yml
+++ b/.github/workflows/run-tests-on-pr.yml
@@ -7,23 +7,9 @@ on:
       - staging
 
 jobs:
-  test:
-    name: Run test suite
+  unit-test:
+    name: Run unit tests
     runs-on: ubuntu-latest
-    services:
-      postgres:
-        image: postgres:12
-        env:
-          POSTGRES_USER: shiba
-          POSTGRES_PASSWORD: shiba
-          POSTGRES_DB: shiba-test
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        ports:
-          - 5432:5432
     steps:
     - uses: actions/checkout@v2
     - name: Set up ChromeDriver
@@ -35,8 +21,27 @@ jobs:
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Test with Gradle
-      run: ./gradlew clean testAll
+      run: ./gradlew unitTest
       env:
         S3_BUCKET: ${{ secrets.S3_TEST_BUCKET }}
         AWS_ACCESS_KEY: ${{ secrets.CLOUD_AWS_CREDENTIALS_ACCESS_KEY }}
         AWS_SECRET_KEY: ${{ secrets.CLOUD_AWS_CREDENTIALS_SECRET_KEY }}
+  db-test:
+    name: Run db tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up ChromeDriver
+        uses: nanasess/setup-chromedriver@v1.0.1
+      - name: Set up JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: '14'
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+      - name: Test with Gradle
+        run: ./gradlew dbTest
+        env:
+          S3_BUCKET: ${{ secrets.S3_TEST_BUCKET }}
+          AWS_ACCESS_KEY: ${{ secrets.CLOUD_AWS_CREDENTIALS_ACCESS_KEY }}
+          AWS_SECRET_KEY: ${{ secrets.CLOUD_AWS_CREDENTIALS_SECRET_KEY }}

--- a/build.gradle
+++ b/build.gradle
@@ -146,7 +146,12 @@ def unitTest = tasks.register("unitTest", Test) {
             JUnitPlatformOptions options ->
                 options.excludeTags("db", "externalService")
         }
-        task.maxParallelForks(Runtime.runtime.availableProcessors().intdiv(2) ?: 1)
+
+        def maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
+        maxParallelForks = Math.max(maxParallelForks, 2);
+        project.logger.lifecycle('maxParallelForks set to ' + maxParallelForks)
+
+        task.maxParallelForks(maxParallelForks)
 }
 
 def dbTest = tasks.register("dbTest", Test) {

--- a/build.gradle
+++ b/build.gradle
@@ -146,12 +146,7 @@ def unitTest = tasks.register("unitTest", Test) {
             JUnitPlatformOptions options ->
                 options.excludeTags("db", "externalService")
         }
-
-        def maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
-        maxParallelForks = Math.max(maxParallelForks, 2);
-        project.logger.lifecycle('maxParallelForks set to ' + maxParallelForks)
-
-        task.maxParallelForks(maxParallelForks)
+        task.maxParallelForks(Runtime.runtime.availableProcessors().intdiv(2) ?: 1)
 }
 
 def dbTest = tasks.register("dbTest", Test) {


### PR DESCRIPTION
Another attempt to speed up tests in CI.

- Also removes the postgres service from our test VMs since we are using H2 now