### PR TITLE
Clarify in email confirmations from Demo that no real application was submitted

### DIFF
--- a/src/main/java/org/codeforamerica/shiba/pages/emails/EmailContentCreator.java
+++ b/src/main/java/org/codeforamerica/shiba/pages/emails/EmailContentCreator.java
@@ -2,6 +2,7 @@ package org.codeforamerica.shiba.pages.emails;
 
 import org.codeforamerica.shiba.output.caf.SnapExpeditedEligibility;
 import org.jetbrains.annotations.Nullable;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.MessageSource;
 import org.springframework.stereotype.Component;
 
@@ -26,9 +27,14 @@ public class EmailContentCreator {
     private final static String LATER_DOCS_CONFIRMATION_EMAIL_SUBJECT = "later-docs.confirmation-email-subject";
     private final static String LATER_DOCS_CONFIRMATION_EMAIL_BODY = "later-docs.confirmation-email-body";
     private final static String LATER_DOCS_CONFIRMATION_EMAIL_LINK = "later-docs.confirmation-email-body-link";
+    private final static String DEMO_PURPOSES_ONLY = "email.demo-purposes-only";
+    private final static String SHARE_FEEDBACK = "email.share-feedback";
+    private final String activeProfile;
 
-    public EmailContentCreator(MessageSource messageSource) {
+
+    public EmailContentCreator(MessageSource messageSource,@Value("${spring.profiles.active:Unknown}")String activeProfile ) {
         this.messageSource = messageSource;
+        this.activeProfile=activeProfile;
     }
 
     public String createClientHTML(String confirmationId, SnapExpeditedEligibility snapExpeditedEligibility, Locale locale) {
@@ -37,6 +43,10 @@ public class EmailContentCreator {
             eligibilitySpecificVerbiage = getMessage(SNAP_EXPEDITED_WAIT_TIME, null, locale);
         } else {
             eligibilitySpecificVerbiage = getMessage(SNAP_NONEXPEDITED_WAIT_TIME, null, locale);
+        }
+
+        if(activeProfile.equals("demo")) {
+            return wrapHtml(getMessage(CLIENT_BODY, List.of(eligibilitySpecificVerbiage, confirmationId), locale) + "<p>" + getMessage(DEMO_PURPOSES_ONLY,null, locale) + "</p><p>" + getMessage(SHARE_FEEDBACK, null, locale) + "</p>");
         }
         return wrapHtml(getMessage(CLIENT_BODY, List.of(eligibilitySpecificVerbiage, confirmationId), locale));
     }

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -1019,6 +1019,8 @@ email.snap-nonexpedited-wait-time=Your county will mail you a notice that will a
 email.client-body=We received your Minnesota Benefits application. {0} <br><br> Confirmation number: <strong>#{1}</strong><br>Application status: <strong>In review</strong><br><br>**This is an automated message. Please do not reply to this message.**
 email.download-caf-alert=The CAF with confirmation number {0} was downloaded from IP address {1}.
 email.non-county-partner-alert=Application {0} was submitted at {1}.
+email.demo-purposes-only=This e-mail is for demo purposes only. No application for benefits was submitted on your behalf.
+email.share-feedback=To share feedback, please get in touch with the Code for America Team, or fill out <a href="https://airtable.com/shrwudOXtR9q6WCXD" target="_blank">this form</a>.
 
 county-to-instructions.default-client=This application was submitted. A caseworker at Hennepin County will help route your application to your county. For more support with your application, you can call Hennepin County at 612-596-1300.
 county-to-instructions.default-caseworker=This application was submitted by a resident at MNbenefits.org, an initiative of DHS and Code for America. This packet contains a completed Combined Application Form (CAF) or Child Care Assistance Program application PDF. Please process like a normal benefits application. If you have any questions, contact your supervisor. If you have any questions about this program or feedback on the application, please email Code for America at mnbenefits@codeforamerica.org.


### PR DESCRIPTION
[#177795275]

Modify emails coming from the demo environment to include messages notifying the recipient that they are receiving this email from demo