### PR TITLE
add findbugs to provide missing annotation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -103,6 +103,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'com.sun.activation:jakarta.activation'
     implementation 'org.springframework:spring-aspects'
+    implementation 'com.google.code.findbugs:jsr305:3.0.2'
     implementation 'org.springframework.retry:spring-retry'
     implementation 'ch.qos.logback.contrib:logback-json-classic:0.1.5'
     implementation 'ch.qos.logback.contrib:logback-jackson:0.1.5'


### PR DESCRIPTION
We see these errors when we deploy to prod:
```
INFO -- : > Task :compileJava
INFO -- : warning: unknown enum constant When.MAYBE

INFO -- :   reason: class file for javax.annotation.meta.When not found
INFO -- : 

INFO -- : warning: unknown enum constant When.MAYBE
INFO -- : 

INFO -- :   reason: class file for javax.annotation.meta.When not found
INFO -- : 

INFO -- : warning: unknown enum constant When.MAYBE
INFO -- : 

INFO -- :   reason: class file for javax.annotation.meta.When not found
INFO -- : 

INFO -- : warning: unknown enum constant When.MAYBE
INFO -- : 

INFO -- :   reason: class file for javax.annotation.meta.When not found
INFO -- : 
```
This fixes that apparently https://stackoverflow.com/questions/53326271/spring-nullable-annotation-generates-unknown-enum-constant-warning
