### PR TITLE
Create a new journey test for the later docs flow

### DIFF
--- a/src/test/java/org/codeforamerica/shiba/AbstractBasePageTest.java
+++ b/src/test/java/org/codeforamerica/shiba/AbstractBasePageTest.java
@@ -8,6 +8,7 @@ import org.codeforamerica.shiba.pages.Page;
 import org.codeforamerica.shiba.pages.SuccessPage;
 import org.codeforamerica.shiba.pages.enrichment.Address;
 import org.codeforamerica.shiba.pages.enrichment.smartystreets.SmartyStreetClient;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -31,6 +32,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.util.*;
+import java.util.concurrent.Callable;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -473,5 +475,10 @@ public abstract class AbstractBasePageTest {
 
     protected String getAttributeForElementAtIndex(List<WebElement> elementList, int index, String attributeName) {
         return elementList.get(index).getAttribute(attributeName);
+    }
+
+    @NotNull
+    protected Callable<Boolean> uploadCompletes() {
+        return () -> !getAttributeForElementAtIndex(driver.findElementsByClassName("dz-remove"), 0, "innerHTML").isBlank();
     }
 }

--- a/src/test/java/org/codeforamerica/shiba/newjourneys/LaterDocsJourneyTest.java
+++ b/src/test/java/org/codeforamerica/shiba/newjourneys/LaterDocsJourneyTest.java
@@ -1,0 +1,77 @@
+package org.codeforamerica.shiba.newjourneys;
+
+import org.codeforamerica.shiba.pages.config.FeatureFlag;
+import org.codeforamerica.shiba.pages.journeys.JourneyTest;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@Tag("journey")
+public class LaterDocsJourneyTest extends JourneyTest {
+    @Test
+    void laterDocsFlow() {
+        when(featureFlagConfiguration.get("county-hennepin")).thenReturn(FeatureFlag.ON);
+        when(featureFlagConfiguration.get("county-morrison")).thenReturn(FeatureFlag.OFF);
+        when(featureFlagConfiguration.get("submit-via-api")).thenReturn(FeatureFlag.ON);
+
+
+        // WHEN V2 IS ENABLED IT...
+        // should give the option to enter zip instead of county
+        when(featureFlagConfiguration.get("later-docs-v2-feature")).thenReturn(FeatureFlag.ON);
+
+        testPage.clickButton("Upload documents");
+
+        assertThat(driver.getTitle()).isEqualTo("Identify County");
+        testPage.clickLink("Enter my zip code instead.");
+        assertThat(driver.getTitle()).isEqualTo("Identify zip");
+
+        // should direct me to email the county if my zipcode is unrecognized or unsupported
+        testPage.enter("zipCode", "11111");
+        testPage.clickContinue();
+        assertThat(driver.getTitle()).isEqualTo("Email Docs To Your County");
+
+        // should allow me to proceed with the flow if I enter a zip code for an active county
+        testPage.clickLink("< Go Back");
+        testPage.enter("zipCode", "55444");
+        testPage.clickContinue();
+        assertThat(driver.getTitle()).isEqualTo("Match Info");
+
+
+        // WHEN V2 IS DISABLED IT...
+        // should not allow me to enter my zip code
+        when(featureFlagConfiguration.get("later-docs-v2-feature")).thenReturn(FeatureFlag.OFF);
+        navigateTo("identifyCounty");
+        assertThat(driver.findElementsByLinkText("Enter my zip code instead.")).isEmpty();
+
+        // should direct me to email docs to my county if my county is not supported
+        testPage.enter("county", "Morrison");
+        testPage.clickContinue();
+        assertThat(driver.getTitle()).isEqualTo("Email Docs To Your County");
+
+        // should allow me to enter personal info and continue the flow if my county is supported
+        testPage.clickLink("< Go Back");
+        testPage.enter("county", "Hennepin");
+        testPage.clickContinue();
+
+        assertThat(driver.getTitle()).isEqualTo("Match Info");
+        testPage.enter("firstName", "defaultFirstName");
+        testPage.enter("lastName", "defaultLastName");
+        testPage.enter("dateOfBirth", "01/12/1928");
+        testPage.enter("ssn", "123456789");
+        testPage.enter("caseNumber", "1234567");
+        testPage.clickContinue();
+
+        // should allow me to upload documents and those documents should be sent to the ESB
+        assertThat(driver.getTitle()).isEqualTo("Upload Documents");
+        uploadPdfFile();
+        await().until(uploadCompletes());
+        testPage.clickButton("I'm finished uploading");
+        assertThat(driver.getTitle()).isEqualTo("Documents Sent");
+        verify(pageEventPublisher).publish(any());
+    }
+}

--- a/src/test/java/org/codeforamerica/shiba/pages/journeys/JourneyTest.java
+++ b/src/test/java/org/codeforamerica/shiba/pages/journeys/JourneyTest.java
@@ -28,10 +28,14 @@ public abstract class JourneyTest extends AbstractBasePageTest {
     protected SmartyStreetClient smartyStreetClient;
     @SpyBean
     protected DocumentRepositoryService documentRepositoryService;
-    @MockBean PageEventPublisher pageEventPublisher;
-    @MockBean MailGunEmailClient mailGunEmailClient;
-    @MockBean FeatureFlagConfiguration featureFlagConfiguration;
-    @SpyBean UploadDocumentConfiguration uploadDocumentConfiguration;
+    @MockBean
+    protected PageEventPublisher pageEventPublisher;
+    @MockBean
+    protected MailGunEmailClient mailGunEmailClient;
+    @MockBean
+    protected FeatureFlagConfiguration featureFlagConfiguration;
+    @SpyBean
+    protected UploadDocumentConfiguration uploadDocumentConfiguration;
 
     @Override
     @BeforeEach

--- a/src/test/java/org/codeforamerica/shiba/pages/journeys/UserJourneyPageTest.java
+++ b/src/test/java/org/codeforamerica/shiba/pages/journeys/UserJourneyPageTest.java
@@ -3,7 +3,6 @@ package org.codeforamerica.shiba.pages.journeys;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.interactive.form.PDAcroForm;
 import org.codeforamerica.shiba.pages.SuccessPage;
-import org.codeforamerica.shiba.pages.config.FeatureFlag;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -20,96 +19,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.codeforamerica.shiba.pages.YesNoAnswer.NO;
 import static org.codeforamerica.shiba.pages.YesNoAnswer.YES;
-import static org.mockito.Mockito.when;
 
 @Tag("journey")
 public class UserJourneyPageTest extends JourneyTest {
-
     @Test
     void intercomButtonIsPresent() {
         await().atMost(5, TimeUnit.SECONDS).until(() -> !driver.findElementsById("intercom-frame").isEmpty());
         assertThat(driver.findElementById("intercom-frame")).isNotNull();
-    }
-    
-    @Test
-    void laterDocsEmailYourCountyFlow() {
-        when(featureFlagConfiguration.get("county-hennepin")).thenReturn(FeatureFlag.ON);
-        when(featureFlagConfiguration.get("county-morrison")).thenReturn(FeatureFlag.OFF);
-
-    	testPage.clickButton("Upload documents");
-        assertThat(driver.getTitle()).isEqualTo("Identify County");
-
-        testPage.enter("county", "Hennepin");
-        testPage.clickContinue();
-        assertThat(driver.getTitle()).isEqualTo("Match Info");
-
-        testPage.clickLink("< Go Back");
-        testPage.enter("county", "Morrison");
-        testPage.clickContinue();
-        assertThat(driver.getTitle()).isEqualTo("Email Docs To Your County");
-    }
-
-    @Test
-    void laterDocsSubmissionFlow() {
-        when(featureFlagConfiguration.get("county-hennepin")).thenReturn(FeatureFlag.ON);
-
-        testPage.clickButton("Upload documents");
-        assertThat(driver.getTitle()).isEqualTo("Identify County");
-
-        testPage.enter("county", "Hennepin");
-        testPage.clickContinue();
-
-        assertThat(driver.getTitle()).isEqualTo("Match Info");
-        testPage.enter("firstName", "defaultFirstName");
-        testPage.enter("lastName", "defaultLastName");
-        testPage.enter("dateOfBirth", "01/12/1928");
-        testPage.enter("ssn", "123456789");
-        testPage.enter("caseNumber", "1234567");
-        testPage.clickContinue();
-
-        assertThat(driver.getTitle()).isEqualTo("Upload Documents");
-
-        uploadPdfFile();
-        await().until(() -> !getAttributeForElementAtIndex(driver.findElementsByClassName("dz-remove"), 0, "innerHTML").isBlank());
-
-        testPage.clickButton("I'm finished uploading");
-        assertThat(driver.getTitle()).isEqualTo("Documents Sent");
-    }
-
-    @Test
-    void laterDocsEnterZipcode() {
-        when(featureFlagConfiguration.get("later-docs-v2-feature")).thenReturn(FeatureFlag.ON);
-        testPage.clickButton("Upload documents");
-        assertThat(driver.getTitle()).isEqualTo("Identify County");
-
-        testPage.clickLink("Enter my zip code instead.");
-        assertThat(driver.getTitle()).isEqualTo("Identify zip");
-
-        testPage.clickLink("Select my county instead.");
-        assertThat(driver.getTitle()).isEqualTo("Identify County");
-
-        when(featureFlagConfiguration.get("later-docs-v2-feature")).thenReturn(FeatureFlag.OFF);
-        navigateTo("identifyCounty");
-        assertThat(driver.findElementsByLinkText("Enter my zip code instead.")).isEmpty();
-    }
-
-    @Test
-    void laterDocsZipcodeNavigation() {
-        when(featureFlagConfiguration.get("county-hennepin")).thenReturn(FeatureFlag.ON);
-        when(featureFlagConfiguration.get("later-docs-v2-feature")).thenReturn(FeatureFlag.ON);
-
-        // Unrecognized or inactive county zipcode
-        testPage.clickButton("Upload documents");
-        navigateTo("identifyZipcode");
-        testPage.enter("zipCode", "11111");
-        testPage.clickContinue();
-        assertThat(driver.getTitle()).isEqualTo("Email Docs To Your County");
-
-        // Active county
-        testPage.clickLink("< Go Back");
-        testPage.enter("zipCode", "55444");
-        testPage.clickContinue();
-        assertThat(driver.getTitle()).isEqualTo("Match Info");
     }
 
     @Test


### PR DESCRIPTION
- Combine all of the later docs E2E tests into a single journey test
- Put the new test in a distinct package called "newjourneys". (Totally open to suggestions about better names!) This is to draw a line between our suite of new, happy path journey tests and our old E2E tests that we will ultimately be converting to mockmvc or unit tests. 
- Just combining these tests seems to have shaved ~7s off of the total test time, which is a good sign that this approach of making a small number of looong Journey tests will pay off.

[#178367703]