### PR TITLE
Refactor GrossMonthlyIncomeParser without config

### DIFF
--- a/src/main/java/org/codeforamerica/shiba/application/parsers/ApplicationDataParserV2.java
+++ b/src/main/java/org/codeforamerica/shiba/application/parsers/ApplicationDataParserV2.java
@@ -1,0 +1,59 @@
+package org.codeforamerica.shiba.application.parsers;
+
+import lombok.Getter;
+import org.codeforamerica.shiba.pages.data.ApplicationData;
+import org.codeforamerica.shiba.pages.data.PagesData;
+
+import java.util.List;
+
+public class ApplicationDataParserV2 {
+    private final ApplicationData applicationData;
+
+    enum Field {
+        PAID_BY_THE_HOUR("paidByTheHour", "paidByTheHour"),
+        HOURLY_WAGE("hourlyWage", "hourlyWage"),
+        HOURS_A_WEEK("hoursAWeek", "hoursAWeek"),
+        PAY_PERIOD("payPeriod", "payPeriod"),
+        INCOME_PER_PAY_PERIOD("incomePerPayPeriod", "incomePerPayPeriod"),
+        LAST_THIRTY_DAYS_JOB_INCOME("lastThirtyDaysJobIncome", "lastThirtyDaysJobIncome");
+
+        @Getter
+        private final String pageName;
+        @Getter
+        private final String inputName;
+        private String defaultValue = null;
+
+        Field(String pageName, String inputName) {
+            this.pageName = pageName;
+            this.inputName = inputName;
+        }
+
+        Field(String pageName, String inputName, String defaultValue) {
+            this.pageName = pageName;
+            this.inputName = inputName;
+            this.defaultValue = defaultValue;
+        }
+    }
+
+    public ApplicationDataParserV2(ApplicationData applicationData) {
+        this.applicationData = applicationData;
+    }
+
+    public List<String> getValues(Field field) {
+        return applicationData.getPagesData().safeGetPageInputValue(field.getPageName(), field.getInputName());
+    }
+
+    public String getFirstValue(Field field) {
+        String pageInputValue = applicationData.getPagesData().getPageInputFirstValue(field.getPageName(), field.getInputName());
+        return pageInputValue == null ? field.defaultValue : pageInputValue;
+    }
+
+    public static List<String> getValues(PagesData pagesData, Field field) {
+        return pagesData.safeGetPageInputValue(field.getPageName(), field.getInputName());
+    }
+
+    public static String getFirstValue(PagesData pagesData, Field field) {
+        String pageInputValue = pagesData.getPageInputFirstValue(field.getPageName(), field.getInputName());
+        return pageInputValue == null ? field.defaultValue : pageInputValue;
+    }
+}

--- a/src/main/java/org/codeforamerica/shiba/application/parsers/ApplicationDataParserV2.java
+++ b/src/main/java/org/codeforamerica/shiba/application/parsers/ApplicationDataParserV2.java
@@ -1,7 +1,9 @@
 package org.codeforamerica.shiba.application.parsers;
 
 import lombok.Getter;
+import org.codeforamerica.shiba.pages.data.ApplicationData;
 import org.codeforamerica.shiba.pages.data.PagesData;
+import org.codeforamerica.shiba.pages.data.Subworkflow;
 
 import java.util.HashMap;
 import java.util.List;
@@ -18,7 +20,12 @@ public class ApplicationDataParserV2 {
         HOURS_A_WEEK,
         PAY_PERIOD,
         INCOME_PER_PAY_PERIOD,
-        LAST_THIRTY_DAYS_JOB_INCOME;
+        LAST_THIRTY_DAYS_JOB_INCOME
+    }
+
+    public enum Group {
+        JOBS,
+        HOUSEHOLD
     }
 
     /**
@@ -32,7 +39,12 @@ public class ApplicationDataParserV2 {
         coordinatesMap.put(Field.PAY_PERIOD, new ParsingCoordinate("payPeriod", "payPeriod"));
         coordinatesMap.put(Field.INCOME_PER_PAY_PERIOD, new ParsingCoordinate("incomePerPayPeriod", "incomePerPayPeriod"));
         coordinatesMap.put(Field.LAST_THIRTY_DAYS_JOB_INCOME, new ParsingCoordinate("lastThirtyDaysJobIncome", "lastThirtyDaysJobIncome"));
+    }
 
+    private static final Map<Group, String> groupCoordinatesMap = new HashMap<>();
+    static {
+        groupCoordinatesMap.put(Group.JOBS, "jobs");
+        groupCoordinatesMap.put(Group.HOUSEHOLD, "household");
     }
 
     @Getter
@@ -62,5 +74,9 @@ public class ApplicationDataParserV2 {
         ParsingCoordinate coordinate = coordinatesMap.get(field);
         String pageInputValue = pagesData.getPageInputFirstValue(coordinate.getPageName(), coordinate.getInputName());
         return pageInputValue == null ? coordinate.getDefaultValue() : pageInputValue;
+    }
+
+    public static Subworkflow getGroup(ApplicationData applicationData, Group group) {
+        return applicationData.getSubworkflows().get(groupCoordinatesMap.get(group));
     }
 }

--- a/src/main/java/org/codeforamerica/shiba/application/parsers/ApplicationDataParserV2.java
+++ b/src/main/java/org/codeforamerica/shiba/application/parsers/ApplicationDataParserV2.java
@@ -1,59 +1,66 @@
 package org.codeforamerica.shiba.application.parsers;
 
 import lombok.Getter;
-import org.codeforamerica.shiba.pages.data.ApplicationData;
 import org.codeforamerica.shiba.pages.data.PagesData;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class ApplicationDataParserV2 {
-    private final ApplicationData applicationData;
 
-    enum Field {
-        PAID_BY_THE_HOUR("paidByTheHour", "paidByTheHour"),
-        HOURLY_WAGE("hourlyWage", "hourlyWage"),
-        HOURS_A_WEEK("hoursAWeek", "hoursAWeek"),
-        PAY_PERIOD("payPeriod", "payPeriod"),
-        INCOME_PER_PAY_PERIOD("incomePerPayPeriod", "incomePerPayPeriod"),
-        LAST_THIRTY_DAYS_JOB_INCOME("lastThirtyDaysJobIncome", "lastThirtyDaysJobIncome");
+    /**
+     * Retrievable fields
+     */
+    public enum Field {
+        PAID_BY_THE_HOUR,
+        HOURLY_WAGE,
+        HOURS_A_WEEK,
+        PAY_PERIOD,
+        INCOME_PER_PAY_PERIOD,
+        LAST_THIRTY_DAYS_JOB_INCOME;
+    }
 
-        @Getter
+    /**
+     * Mapping configuration
+     */
+    private static final Map<Field, ParsingCoordinate> coordinatesMap = new HashMap<>();
+    static {
+        coordinatesMap.put(Field.PAID_BY_THE_HOUR, new ParsingCoordinate("paidByTheHour", "paidByTheHour"));
+        coordinatesMap.put(Field.HOURLY_WAGE, new ParsingCoordinate("hourlyWage", "hourlyWage"));
+        coordinatesMap.put(Field.HOURS_A_WEEK, new ParsingCoordinate("hoursAWeek", "hoursAWeek"));
+        coordinatesMap.put(Field.PAY_PERIOD, new ParsingCoordinate("payPeriod", "payPeriod"));
+        coordinatesMap.put(Field.INCOME_PER_PAY_PERIOD, new ParsingCoordinate("incomePerPayPeriod", "incomePerPayPeriod"));
+        coordinatesMap.put(Field.LAST_THIRTY_DAYS_JOB_INCOME, new ParsingCoordinate("lastThirtyDaysJobIncome", "lastThirtyDaysJobIncome"));
+
+    }
+
+    @Getter
+    private static class ParsingCoordinate {
         private final String pageName;
-        @Getter
         private final String inputName;
         private String defaultValue = null;
 
-        Field(String pageName, String inputName) {
+        ParsingCoordinate(String pageName, String inputName) {
             this.pageName = pageName;
             this.inputName = inputName;
         }
 
-        Field(String pageName, String inputName, String defaultValue) {
+        ParsingCoordinate(String pageName, String inputName, String defaultValue) {
             this.pageName = pageName;
             this.inputName = inputName;
             this.defaultValue = defaultValue;
         }
     }
 
-    public ApplicationDataParserV2(ApplicationData applicationData) {
-        this.applicationData = applicationData;
-    }
-
-    public List<String> getValues(Field field) {
-        return applicationData.getPagesData().safeGetPageInputValue(field.getPageName(), field.getInputName());
-    }
-
-    public String getFirstValue(Field field) {
-        String pageInputValue = applicationData.getPagesData().getPageInputFirstValue(field.getPageName(), field.getInputName());
-        return pageInputValue == null ? field.defaultValue : pageInputValue;
-    }
-
     public static List<String> getValues(PagesData pagesData, Field field) {
-        return pagesData.safeGetPageInputValue(field.getPageName(), field.getInputName());
+        ParsingCoordinate coordinate = coordinatesMap.get(field);
+        return pagesData.safeGetPageInputValue(coordinate.getPageName(), coordinate.getInputName());
     }
 
     public static String getFirstValue(PagesData pagesData, Field field) {
-        String pageInputValue = pagesData.getPageInputFirstValue(field.getPageName(), field.getInputName());
-        return pageInputValue == null ? field.defaultValue : pageInputValue;
+        ParsingCoordinate coordinate = coordinatesMap.get(field);
+        String pageInputValue = pagesData.getPageInputFirstValue(coordinate.getPageName(), coordinate.getInputName());
+        return pageInputValue == null ? coordinate.getDefaultValue() : pageInputValue;
     }
 }

--- a/src/main/java/org/codeforamerica/shiba/application/parsers/GrossMonthlyIncomeParser.java
+++ b/src/main/java/org/codeforamerica/shiba/application/parsers/GrossMonthlyIncomeParser.java
@@ -47,8 +47,4 @@ public class GrossMonthlyIncomeParser {
                 .filter(JobIncomeInformation::isComplete)
                 .collect(Collectors.toList());
     }
-
-    private String parseValue(String pageInput, PagesData pagesData) {
-        return super.parseValue(parsingConfiguration.get("grossMonthlyIncome").getPageInputs().get(pageInput), pagesData);
-    }
 }

--- a/src/main/java/org/codeforamerica/shiba/application/parsers/GrossMonthlyIncomeParser.java
+++ b/src/main/java/org/codeforamerica/shiba/application/parsers/GrossMonthlyIncomeParser.java
@@ -13,14 +13,16 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static org.codeforamerica.shiba.application.parsers.ApplicationDataParserV2.*;
 import static org.codeforamerica.shiba.application.parsers.ApplicationDataParserV2.Field.*;
 import static org.codeforamerica.shiba.application.parsers.ApplicationDataParserV2.getFirstValue;
+import static org.codeforamerica.shiba.application.parsers.ApplicationDataParserV2.getGroup;
 
 @Component
 public class GrossMonthlyIncomeParser {
 
     public List<JobIncomeInformation> parse(ApplicationData data) {
-        Subworkflow jobsGroup = data.getSubworkflows().get("jobs");
+        Subworkflow jobsGroup = getGroup(data, Group.JOBS);
         if (jobsGroup == null) {
             return Collections.emptyList();
         }

--- a/src/main/java/org/codeforamerica/shiba/application/parsers/SnapExpeditedEligibilityParser.java
+++ b/src/main/java/org/codeforamerica/shiba/application/parsers/SnapExpeditedEligibilityParser.java
@@ -1,7 +1,6 @@
 package org.codeforamerica.shiba.application.parsers;
 
 import org.codeforamerica.shiba.Money;
-import org.codeforamerica.shiba.output.caf.JobIncomeInformation;
 import org.codeforamerica.shiba.output.caf.SnapExpeditedEligibilityParameters;
 import org.codeforamerica.shiba.pages.data.ApplicationData;
 import org.codeforamerica.shiba.pages.data.Iteration;
@@ -16,10 +15,10 @@ import java.util.Optional;
 
 @Component
 public class SnapExpeditedEligibilityParser extends ApplicationDataParser<Optional<SnapExpeditedEligibilityParameters>> {
-    private final ApplicationDataParser<List<JobIncomeInformation>> grossMonthlyIncomeParser;
+    private final GrossMonthlyIncomeParser grossMonthlyIncomeParser;
 
     public SnapExpeditedEligibilityParser(ParsingConfiguration parsingConfiguration,
-                                          ApplicationDataParser<List<JobIncomeInformation>> grossMonthlyIncomeParser) {
+                                          GrossMonthlyIncomeParser grossMonthlyIncomeParser) {
         super(parsingConfiguration);
         this.grossMonthlyIncomeParser = grossMonthlyIncomeParser;
     }

--- a/src/main/java/org/codeforamerica/shiba/application/parsers/TotalIncomeParser.java
+++ b/src/main/java/org/codeforamerica/shiba/application/parsers/TotalIncomeParser.java
@@ -1,19 +1,16 @@
 package org.codeforamerica.shiba.application.parsers;
 
 import org.codeforamerica.shiba.Money;
-import org.codeforamerica.shiba.output.caf.JobIncomeInformation;
 import org.codeforamerica.shiba.output.caf.TotalIncome;
 import org.codeforamerica.shiba.pages.data.ApplicationData;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
-
 @Component
 public class TotalIncomeParser extends ApplicationDataParser<TotalIncome> {
-    private final ApplicationDataParser<List<JobIncomeInformation>> grossIncomeParser;
+    private final GrossMonthlyIncomeParser grossIncomeParser;
 
     public TotalIncomeParser(ParsingConfiguration parsingConfiguration,
-                             ApplicationDataParser<List<JobIncomeInformation>> grossIncomeParser) {
+                             GrossMonthlyIncomeParser grossIncomeParser) {
         super(parsingConfiguration);
         this.grossIncomeParser = grossIncomeParser;
     }

--- a/src/main/java/org/codeforamerica/shiba/output/caf/GrossMonthlyIncomeMapper.java
+++ b/src/main/java/org/codeforamerica/shiba/output/caf/GrossMonthlyIncomeMapper.java
@@ -1,7 +1,7 @@
 package org.codeforamerica.shiba.output.caf;
 
 import org.codeforamerica.shiba.application.Application;
-import org.codeforamerica.shiba.application.parsers.ApplicationDataParser;
+import org.codeforamerica.shiba.application.parsers.GrossMonthlyIncomeParser;
 import org.codeforamerica.shiba.output.ApplicationInput;
 import org.codeforamerica.shiba.output.Document;
 import org.codeforamerica.shiba.output.Recipient;
@@ -22,9 +22,9 @@ import static org.codeforamerica.shiba.output.ApplicationInputType.SINGLE_VALUE;
 public class GrossMonthlyIncomeMapper implements ApplicationInputsMapper {
 
     private final ApplicationConfiguration applicationConfiguration;
-    private final ApplicationDataParser<List<JobIncomeInformation>> grossMonthlyIncomeParser;
+    private final GrossMonthlyIncomeParser grossMonthlyIncomeParser;
 
-    public GrossMonthlyIncomeMapper(ApplicationDataParser<List<JobIncomeInformation>> grossMonthlyIncomeParser, ApplicationConfiguration applicationConfiguration) {
+    public GrossMonthlyIncomeMapper(GrossMonthlyIncomeParser grossMonthlyIncomeParser, ApplicationConfiguration applicationConfiguration) {
         this.grossMonthlyIncomeParser = grossMonthlyIncomeParser;
         this.applicationConfiguration = applicationConfiguration;
     }

--- a/src/test/java/org/codeforamerica/shiba/application/parsers/ApplicationDataParser2Test.java
+++ b/src/test/java/org/codeforamerica/shiba/application/parsers/ApplicationDataParser2Test.java
@@ -9,8 +9,9 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.codeforamerica.shiba.application.parsers.ApplicationDataParserV2.Field.PAID_BY_THE_HOUR;
+import static org.codeforamerica.shiba.application.parsers.ApplicationDataParserV2.Group.JOBS;
 
-class ApplicationDataParser2Test {
+class ApplicationDataParserV2Test {
     private TestApplicationDataBuilder builder;
 
     @BeforeEach
@@ -44,5 +45,12 @@ class ApplicationDataParser2Test {
                 .build();
         value = ApplicationDataParserV2.getFirstValue(applicationData.getPagesData(), PAID_BY_THE_HOUR);
         assertThat(value).isNull();
+    }
+
+    @Test
+    void shouldReturnSubworkflowForExistingGroup() {
+        ApplicationData applicationData = builder.withJobs().build();
+
+        assertThat(ApplicationDataParserV2.getGroup(applicationData, JOBS)).isNotNull();
     }
 }

--- a/src/test/java/org/codeforamerica/shiba/application/parsers/ApplicationDataParser2Test.java
+++ b/src/test/java/org/codeforamerica/shiba/application/parsers/ApplicationDataParser2Test.java
@@ -1,0 +1,48 @@
+package org.codeforamerica.shiba.application.parsers;
+
+import org.codeforamerica.shiba.pages.data.ApplicationData;
+import org.codeforamerica.shiba.pages.data.TestApplicationDataBuilder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.codeforamerica.shiba.application.parsers.ApplicationDataParserV2.Field.PAID_BY_THE_HOUR;
+
+class ApplicationDataParser2Test {
+    private TestApplicationDataBuilder builder;
+
+    @BeforeEach
+    void setUp() {
+        builder = new TestApplicationDataBuilder();
+    }
+
+    @Test
+    void shouldReturnExistingValue() {
+        String expectedValue = "1";
+        ApplicationData applicationData = builder
+                .withPageData("paidByTheHour", "paidByTheHour", List.of(expectedValue))
+                .build();
+
+        String value = ApplicationDataParserV2.getFirstValue(applicationData.getPagesData(), PAID_BY_THE_HOUR);
+
+        assertThat(value).isEqualTo(expectedValue);
+    }
+
+    @Test
+    void shouldReturnNullForMissingPageOrInput() {
+        String expectedValue = "1";
+        ApplicationData applicationData = builder
+                .withPageData("shmaidByTheHour", "paidByTheHour", List.of(expectedValue))
+                .build();
+        String value = ApplicationDataParserV2.getFirstValue(applicationData.getPagesData(), PAID_BY_THE_HOUR);
+        assertThat(value).isNull();
+
+        applicationData = builder
+                .withPageData("paidByTheHour", "shmaidByTheHour", List.of(expectedValue))
+                .build();
+        value = ApplicationDataParserV2.getFirstValue(applicationData.getPagesData(), PAID_BY_THE_HOUR);
+        assertThat(value).isNull();
+    }
+}

--- a/src/test/java/org/codeforamerica/shiba/application/parsers/GrossMonthlyIncomeParserTest.java
+++ b/src/test/java/org/codeforamerica/shiba/application/parsers/GrossMonthlyIncomeParserTest.java
@@ -5,7 +5,10 @@ import org.codeforamerica.shiba.PagesDataBuilder;
 import org.codeforamerica.shiba.output.caf.HourlyJobIncomeInformation;
 import org.codeforamerica.shiba.output.caf.JobIncomeInformation;
 import org.codeforamerica.shiba.output.caf.NonHourlyJobIncomeInformation;
-import org.codeforamerica.shiba.pages.data.*;
+import org.codeforamerica.shiba.pages.data.ApplicationData;
+import org.codeforamerica.shiba.pages.data.PagesData;
+import org.codeforamerica.shiba.pages.data.Subworkflow;
+import org.codeforamerica.shiba.pages.data.Subworkflows;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -14,47 +17,31 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class GrossMonthlyIncomeParserTest extends AbstractParserTest {
+class GrossMonthlyIncomeParserTest {
     private ApplicationData applicationData;
-    private GrossMonthlyIncomeParser grossMonthlyIncomeParser;
-    private PagesDataBuilder pagesDataBuilder;
+    private final GrossMonthlyIncomeParser grossMonthlyIncomeParser = new GrossMonthlyIncomeParser();
+    private final PagesDataBuilder pagesDataBuilder = new PagesDataBuilder();
 
     @BeforeEach
     void setUp() {
         applicationData = new ApplicationData();
-        pagesDataBuilder = new PagesDataBuilder();
-        grossMonthlyIncomeParser = new GrossMonthlyIncomeParser(parsingConfiguration);
     }
 
     @Test
     void shouldProvideHourlyJobInformation() {
-        Subworkflows subworkflows = new Subworkflows();
-
         Subworkflow subworkflow = new Subworkflow();
-        PagesData pagesData1 = new PagesData();
-        PageData paidByTheHourPageData1 = new PageData();
-        paidByTheHourPageData1.put("paidByTheHourInput", InputData.builder().value(List.of("true")).build());
-        pagesData1.put("paidByTheHourPage", paidByTheHourPageData1);
-        PageData hourlyWagePageData1 = new PageData();
-        hourlyWagePageData1.put("hourlyWageInput", InputData.builder().value(List.of("12")).build());
-        pagesData1.put("hourlyWagePage", hourlyWagePageData1);
-        PageData hoursAWeekPageData1 = new PageData();
-        hoursAWeekPageData1.put("hoursAWeekInput", InputData.builder().value(List.of("30")).build());
-        pagesData1.put("hoursAWeekPage", hoursAWeekPageData1);
-        subworkflow.add(pagesData1);
-
-        PagesData pagesData2 = new PagesData();
-        PageData paidByTheHourPageData2 = new PageData();
-        paidByTheHourPageData2.put("paidByTheHourInput", InputData.builder().value(List.of("true")).build());
-        pagesData2.put("paidByTheHourPage", paidByTheHourPageData2);
-        PageData hourlyWagePageData2 = new PageData();
-        hourlyWagePageData2.put("hourlyWageInput", InputData.builder().value(List.of("6")).build());
-        pagesData2.put("hourlyWagePage", hourlyWagePageData2);
-        PageData hoursAWeekPageData2 = new PageData();
-        hoursAWeekPageData2.put("hoursAWeekInput", InputData.builder().value(List.of("45")).build());
-        pagesData2.put("hoursAWeekPage", hoursAWeekPageData2);
-        subworkflow.add(pagesData2);
-        subworkflows.put("jobsGroup", subworkflow);
+        subworkflow.add(pagesDataBuilder.build(List.of(
+                new PageDataBuilder("paidByTheHour", Map.of("paidByTheHour", List.of("true"))),
+                new PageDataBuilder("hourlyWage", Map.of("hourlyWage", List.of("12"))),
+                new PageDataBuilder("hoursAWeek", Map.of("hoursAWeek", List.of("30")))
+        )));
+        subworkflow.add(pagesDataBuilder.build(List.of(
+                new PageDataBuilder("paidByTheHour", Map.of("paidByTheHour", List.of("true"))),
+                new PageDataBuilder("hourlyWage", Map.of("hourlyWage", List.of("6"))),
+                new PageDataBuilder("hoursAWeek", Map.of("hoursAWeek", List.of("45")))
+        )));
+        Subworkflows subworkflows = new Subworkflows();
+        subworkflows.put("jobs", subworkflow);
 
         applicationData.setSubworkflows(subworkflows);
 
@@ -69,23 +56,23 @@ class GrossMonthlyIncomeParserTest extends AbstractParserTest {
     @Test
     void shouldNotProvideJobInformationForJobsWithInsufficientInformationForCalculation() {
         PagesData hourlyJobPagesData = pagesDataBuilder.build(List.of(
-                new PageDataBuilder("paidByTheHourPage", Map.of("paidByTheHourInput", List.of("true"))),
-                new PageDataBuilder("hourlyWagePage", Map.of("hourlyWageInput", List.of(""))),
-                new PageDataBuilder("hoursAWeekPage", Map.of("hoursAWeekInput", List.of("")))
+                new PageDataBuilder("paidByTheHour", Map.of("paidByTheHour", List.of("true"))),
+                new PageDataBuilder("hourlyWage", Map.of("hourlyWage", List.of(""))),
+                new PageDataBuilder("hoursAWeek", Map.of("hoursAWeek", List.of("")))
         ));
 
         PagesData nonHourlyJobPagesData = pagesDataBuilder.build(List.of(
-                new PageDataBuilder("paidByTheHourPage", Map.of("paidByTheHourInput", List.of("false"))),
-                new PageDataBuilder("payPeriodPage", Map.of("payPeriodInput", List.of(""))),
-                new PageDataBuilder("incomePerPayPeriodPage", Map.of("incomePerPayPeriodInput", List.of(""))),
-                new PageDataBuilder("last30DaysJobIncomePage", Map.of("last30DaysJobIncomeInput", List.of("")))
+                new PageDataBuilder("paidByTheHour", Map.of("paidByTheHour", List.of("false"))),
+                new PageDataBuilder("payPeriod", Map.of("payPeriod", List.of(""))),
+                new PageDataBuilder("incomePerPayPeriod", Map.of("incomePerPayPeriod", List.of(""))),
+                new PageDataBuilder("last30DaysJobIncome", Map.of("last30DaysJobIncome", List.of("")))
         ));
 
         Subworkflow subworkflow = new Subworkflow();
         Subworkflows subworkflows = new Subworkflows();
         subworkflow.add(hourlyJobPagesData);
         subworkflow.add(nonHourlyJobPagesData);
-        subworkflows.put("jobsGroup", subworkflow);
+        subworkflows.put("jobs", subworkflow);
         applicationData.setSubworkflows(subworkflows);
 
         List<JobIncomeInformation> jobIncomeInformation = grossMonthlyIncomeParser.parse(applicationData);
@@ -102,24 +89,15 @@ class GrossMonthlyIncomeParserTest extends AbstractParserTest {
 
     @Test
     void shouldProvideNonHourlyJobInformation() {
-        Subworkflows subworkflows = new Subworkflows();
         Subworkflow subworkflow = new Subworkflow();
-        PagesData pagesData = new PagesData();
+        subworkflow.add(pagesDataBuilder.build(List.of(
+                new PageDataBuilder("paidByTheHour", Map.of("paidByTheHour", List.of("false"))),
+                new PageDataBuilder("payPeriod", Map.of("payPeriod", List.of("EVERY_WEEK"))),
+                new PageDataBuilder("incomePerPayPeriod", Map.of("incomePerPayPeriod", List.of("1.1")))
+        )));
 
-        PageData paidByTheHourPageData = new PageData();
-        paidByTheHourPageData.put("paidByTheHourInput", InputData.builder().value(List.of("false")).build());
-        pagesData.put("paidByTheHourPage", paidByTheHourPageData);
-
-        PageData payPeriodPageData = new PageData();
-        payPeriodPageData.put("payPeriodInput", InputData.builder().value(List.of("EVERY_WEEK")).build());
-        pagesData.put("payPeriodPage", payPeriodPageData);
-
-        PageData incomePerPayPeriod = new PageData();
-        incomePerPayPeriod.put("incomePerPayPeriodInput", InputData.builder().value(List.of("1.1")).build());
-        pagesData.put("incomePerPayPeriodPage", incomePerPayPeriod);
-
-        subworkflow.add(pagesData);
-        subworkflows.put("jobsGroup", subworkflow);
+        Subworkflows subworkflows = new Subworkflows();
+        subworkflows.put("jobs", subworkflow);
         applicationData.setSubworkflows(subworkflows);
 
         List<JobIncomeInformation> jobIncomeInformation = grossMonthlyIncomeParser.parse(applicationData);
@@ -133,10 +111,10 @@ class GrossMonthlyIncomeParserTest extends AbstractParserTest {
     void shouldReturnNonHourlyJobInformationIfHourlyJobPageIsNotAvailable() {
         Subworkflow subworkflow = new Subworkflow();
         subworkflow.add(pagesDataBuilder.build(List.of(
-                new PageDataBuilder("payPeriodPage", Map.of("payPeriodInput", List.of("EVERY_WEEK"))),
-                new PageDataBuilder("incomePerPayPeriodPage", Map.of("incomePerPayPeriodInput", List.of("1.1")))
+                new PageDataBuilder("payPeriod", Map.of("payPeriod", List.of("EVERY_WEEK"))),
+                new PageDataBuilder("incomePerPayPeriod", Map.of("incomePerPayPeriod", List.of("1.1")))
         )));
-        applicationData.setSubworkflows(new Subworkflows(Map.of("jobsGroup", subworkflow)));
+        applicationData.setSubworkflows(new Subworkflows(Map.of("jobs", subworkflow)));
 
         List<JobIncomeInformation> jobIncomeInformation = grossMonthlyIncomeParser.parse(applicationData);
 

--- a/src/test/java/org/codeforamerica/shiba/pages/data/TestApplicationDataBuilder.java
+++ b/src/test/java/org/codeforamerica/shiba/pages/data/TestApplicationDataBuilder.java
@@ -1,14 +1,19 @@
 package org.codeforamerica.shiba.pages.data;
 
 
+import org.codeforamerica.shiba.PageDataBuilder;
+import org.codeforamerica.shiba.PagesDataBuilder;
+
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Helper class for building test application data
  */
 public class TestApplicationDataBuilder {
     private final ApplicationData applicationData = new ApplicationData();
+    private final PagesDataBuilder pagesDataBuilder = new PagesDataBuilder();
 
     public ApplicationData build() {
         return applicationData;
@@ -45,6 +50,14 @@ public class TestApplicationDataBuilder {
         PageData pageData = new PageData();
         pageData.put(input, InputData.builder().value(values).build());
         applicationData.getPagesData().put(pageName, pageData);
+        return this;
+    }
+
+    public TestApplicationDataBuilder withJobs() {
+        applicationData.setSubworkflows(new Subworkflows(Map.of("jobs", new Subworkflow(List.of(pagesDataBuilder.build(List.of(
+                new PageDataBuilder("payPeriod", Map.of("payPeriod", List.of("EVERY_WEEK"))),
+                new PageDataBuilder("incomePerPayPeriod", Map.of("incomePerPayPeriod", List.of("1.1")))
+        )))))));
         return this;
     }
 }


### PR DESCRIPTION
Refactor GrossMonthlyIncomeParser to not use the parsing configuration and instead use a new ApplicationDataParserV2 (which would hypothetically replace ApplicationDataParser).
ApplicationDataParserV2 has a `Field` enum which would correspond to the parsing-coordinates in the parsing-config

Pros:
- ApplicationDataParserV2 is static so it does not need to be initialized or passed in constructors.

Cons:
- All the tests would need to be updated to setup application data with the expected values or the static methods would need to be mocked, which is tedious but not necessarily bad
- Probably less readable than putting into a config file

[#178403952]