### PR TITLE
Reduce the number of end to end tests for uploading documents; actually upload documents to Azure in tests

### DIFF
--- a/src/main/java/org/codeforamerica/shiba/pages/DocRecommendationMessageService.java
+++ b/src/main/java/org/codeforamerica/shiba/pages/DocRecommendationMessageService.java
@@ -97,7 +97,6 @@ public class DocRecommendationMessageService {
     }
 
     private List<DocumentRecommendation> getShortDocumentRecommendations(List<String> recommendations, LocaleSpecificMessageSource lms) {
-
         List<DocumentRecommendation> recommendationMessages = new ArrayList<>();
         recommendations.forEach(recommendation -> {
             DocumentRecommendation docRec;

--- a/src/test/java/org/codeforamerica/shiba/AbstractBasePageTest.java
+++ b/src/test/java/org/codeforamerica/shiba/AbstractBasePageTest.java
@@ -85,7 +85,7 @@ public abstract class AbstractBasePageTest {
         chromePrefs.put("download.default_directory", path.toString());
         options.setExperimentalOption("prefs", chromePrefs);
         options.addArguments("--window-size=1280,1600");
-//        options.addArguments("--headless");
+        options.addArguments("--headless");
         driver = new ChromeDriver(options);
         testPage = new Page(driver);
     }

--- a/src/test/java/org/codeforamerica/shiba/AbstractBasePageTest.java
+++ b/src/test/java/org/codeforamerica/shiba/AbstractBasePageTest.java
@@ -85,7 +85,7 @@ public abstract class AbstractBasePageTest {
         chromePrefs.put("download.default_directory", path.toString());
         options.setExperimentalOption("prefs", chromePrefs);
         options.addArguments("--window-size=1280,1600");
-        options.addArguments("--headless");
+//        options.addArguments("--headless");
         driver = new ChromeDriver(options);
         testPage = new Page(driver);
     }

--- a/src/test/java/org/codeforamerica/shiba/newjourneys/FullFlowJourneyTest.java
+++ b/src/test/java/org/codeforamerica/shiba/newjourneys/FullFlowJourneyTest.java
@@ -624,13 +624,6 @@ public class FullFlowJourneyTest extends JourneyTest {
         assertThat(fileDetails).contains(sizeUnit);
     }
 
-    private void deleteAFile() {
-        testPage.clickLink("delete");
-
-        assertThat(testPage.getTitle()).isEqualTo("Delete a file");
-        testPage.clickButton("Yes, delete the file");
-    }
-
     private void assertStylingOfNonEmptyDocumentUploadPage() {
         assertThat(driver.findElementById("drag-and-drop-box").getAttribute("class")).contains(
                 "drag-and-drop-box-compact");

--- a/src/test/java/org/codeforamerica/shiba/pages/DocRecommendationMessageServiceTest.java
+++ b/src/test/java/org/codeforamerica/shiba/pages/DocRecommendationMessageServiceTest.java
@@ -15,12 +15,10 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
+import java.util.*;
 import java.util.stream.Stream;
 
+import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.mockito.ArgumentMatchers.any;
@@ -123,7 +121,6 @@ public class DocRecommendationMessageServiceTest extends AbstractPageControllerT
         mockMvc.perform(get(pageName).session(new MockHttpSession()))
                 .andExpect(status().isOk())
                 .andExpect(content().string(containsString(expectedMessage)));
-
     }
 
     @Test
@@ -141,16 +138,15 @@ public class DocRecommendationMessageServiceTest extends AbstractPageControllerT
     @Test
     void displayNoDocumentRecommendationsForMinimumFlowSnapApplication() throws Exception {
         // passing no recommendations emulates minimum flow
-        setPageInformation(List.of("SNAP"), List.of());
+        setPageInformation(List.of("SNAP"), emptyList());
 
-        var recommendations = (ArrayList<?>) Objects.requireNonNull(
-                mockMvc.perform(get("/pages/uploadDocuments").session(new MockHttpSession())).andReturn().getModelAndView()
-        ).getModel().get("docRecommendations");
+        var modelAndView = mockMvc.perform(get("/pages/uploadDocuments").session(new MockHttpSession())).andReturn().getModelAndView();
+        var recommendations = (ArrayList<?>) Objects.requireNonNull(modelAndView).getModel().get("docRecommendations");
         assertThat(recommendations).isEmpty();
     }
 
     private void setPageInformation(List<String> programs, List<String> recommendations) {
-        List<PageDataBuilder> pagesData = new ArrayList<>();
+        var pagesData = new ArrayList<PageDataBuilder>();
         pagesData.add(new PageDataBuilder("choosePrograms", Map.of("programs", programs)));
 
         recommendations.forEach(recommendation -> {

--- a/src/test/java/org/codeforamerica/shiba/pages/journeys/AccessibilityJourneyPageTest.java
+++ b/src/test/java/org/codeforamerica/shiba/pages/journeys/AccessibilityJourneyPageTest.java
@@ -3,11 +3,13 @@ package org.codeforamerica.shiba.pages.journeys;
 import com.deque.html.axecore.results.Results;
 import com.deque.html.axecore.results.Rule;
 import com.deque.html.axecore.selenium.AxeBuilder;
+import org.codeforamerica.shiba.documents.CombinedDocumentRepositoryService;
 import org.codeforamerica.shiba.pages.AccessibilityTestPage;
 import org.codeforamerica.shiba.pages.config.FeatureFlag;
 import org.codeforamerica.shiba.pages.enrichment.Address;
 import org.junit.jupiter.api.*;
 import org.openqa.selenium.By;
+import org.springframework.boot.test.mock.mockito.MockBean;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -26,6 +28,9 @@ public class AccessibilityJourneyPageTest extends JourneyTest {
     protected static List<Rule> resultsList = new ArrayList<>();
     protected static Results results;
     protected AccessibilityTestPage testPage;
+
+    @MockBean
+    protected CombinedDocumentRepositoryService documentRepositoryService;
 
     @Override
     @BeforeEach
@@ -245,7 +250,7 @@ public class AccessibilityJourneyPageTest extends JourneyTest {
         List<Rule> violations = results.getViolations();
         System.out.println("Found " + violations.size() + " accessibility related issues.");
         if (results.getViolations().size() > 0) {
-            violations.stream().forEach(violation -> {
+            violations.forEach(violation -> {
                 System.out.println("Rule at issue: " + violation.getId());
                 System.out.println("Rule description: " + violation.getDescription());
                 System.out.println("Rule help text: " + violation.getHelp());

--- a/src/test/java/org/codeforamerica/shiba/pages/journeys/DocumentUploadJourneyTest.java
+++ b/src/test/java/org/codeforamerica/shiba/pages/journeys/DocumentUploadJourneyTest.java
@@ -7,6 +7,8 @@ import org.openqa.selenium.WebElement;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
@@ -14,7 +16,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 
 @Tag("document")
-public class DocumentsTest extends JourneyTest {
+public class DocumentUploadJourneyTest extends JourneyTest {
     @Test
     void whenDocumentUploadFailsThenThereShouldBeAnError() throws InterruptedException {
         doThrow(new InterruptedException())
@@ -31,32 +33,26 @@ public class DocumentsTest extends JourneyTest {
     }
 
     @Test
-    void showMaxFileUploadMessageWhenClientHasUploaded20Documents() {
-        getToDocumentUploadScreen();
-        for (int c = 0; c < 20; c++) {
-            uploadJpgFile();
-        }
-
-        assertThat(driver.findElementById("max-files").getText()).contains("You have uploaded the maximum number of files (20). You will have the opportunity to share more with a county worker later.");
-    }
-
-    @Test
-    void showMaxFilesizeErrorMessageWhenClientHasUploadedLargeDocument() {
-        getToDocumentUploadScreen();
-        long largeFilesize = 21000000L;
-        driver.executeScript("$('#document-upload').get(0).dropzone.addFile({name: 'testFile.pdf', size: " + largeFilesize + ", type: 'not-an-image'})");
-
-        int maxFileSize = uploadDocumentConfiguration.getMaxFilesize();
-        assertThat(driver.findElementByClassName("text--error").getText()).contains("This file is too large and cannot be uploaded (max size: " + maxFileSize + " MB)");
-    }
-
-    @Test
-    void shouldUpdateFileCountWhenRemoveIsClickedIfAnUploadHasAnError() {
+    void shouldShowErrorsAndWarningsProperly() {
         getToDocumentUploadScreen();
         uploadJpgFile();
+
+        // should disallow adding files with types that are not on the allow list
         driver.executeScript("$('#document-upload').get(0).dropzone.addFile({name: 'testFile.xyz', size: 1000, type: 'not-an-image'})");
         assertThat(driver.findElementsByClassName("text--error").get(0).getText()).contains("You can't upload files of this type");
         testPage.clickLink("remove");
         assertThat(driver.findElementById("number-of-uploaded-files").getText()).isEqualTo("1 file added");
+
+        // should show max filesize error message for files that are too big
+        long largeFilesize = 21000000L;
+        driver.executeScript("$('#document-upload').get(0).dropzone.addFile({name: 'testFile.pdf', size: " + largeFilesize + ", type: 'not-an-image'})");
+        int maxFileSize = uploadDocumentConfiguration.getMaxFilesize();
+        assertThat(driver.findElementByClassName("text--error").getText()).contains("This file is too large and cannot be uploaded (max size: " + maxFileSize + " MB)");
+        testPage.clickLink("remove");
+        assertThat(driver.findElementById("number-of-uploaded-files").getText()).isEqualTo("1 file added");
+
+        // should alert the user when they have uploaded the maximum number of files
+        IntStream.range(0, 19).forEach(c -> uploadJpgFile());
+        assertThat(driver.findElementById("max-files").getText()).contains("You have uploaded the maximum number of files (20). You will have the opportunity to share more with a county worker later.");
     }
 }

--- a/src/test/java/org/codeforamerica/shiba/pages/journeys/DocumentsTest.java
+++ b/src/test/java/org/codeforamerica/shiba/pages/journeys/DocumentsTest.java
@@ -10,47 +10,11 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
-import static org.codeforamerica.shiba.pages.YesNoAnswer.NO;
-import static org.codeforamerica.shiba.pages.YesNoAnswer.YES;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 
 @Tag("document")
 public class DocumentsTest extends JourneyTest {
-    @Test
-    void shouldSkipDocumentUploadFlowIfNotApplicableRegardlessOfPrograms() {
-        List<String> applicantPrograms = List.of(PROGRAM_SNAP, PROGRAM_CASH, PROGRAM_EA, PROGRAM_GRH, PROGRAM_CCAP);
-        completeFlowFromLandingPageThroughReviewInfo(applicantPrograms, smartyStreetClient);
-        completeFlowFromReviewInfoToDisability(applicantPrograms);
-
-        // Won't recommend proof of job loss
-        testPage.enter("hasWorkSituation", NO.getDisplayValue());
-        testPage.clickContinue();
-        // Won't recommend proof of income
-        testPage.enter("areYouWorking", NO.getDisplayValue());
-        testPage.enter("currentlyLookingForJob", NO.getDisplayValue());
-        testPage.clickContinue();
-        testPage.enter("unearnedIncome", "None of the above");
-        testPage.clickContinue();
-        testPage.enter("unearnedIncomeCcap", "None of the above");
-        testPage.clickContinue();
-        testPage.enter("earnLessMoneyThisMonth", NO.getDisplayValue());
-        testPage.clickContinue();
-        testPage.clickContinue();
-        // Won't recommend proof of shelter
-        testPage.enter("homeExpenses", "None of the above");
-        testPage.clickContinue();
-        // Won't recommend proof of medical expenses
-        navigateTo("medicalExpenses");
-        testPage.enter("medicalExpenses", "None of the above");
-        testPage.clickContinue();
-        navigateTo("signThisApplication");
-        testPage.enter("applicantSignature", "some name");
-        testPage.clickButton("Submit");
-
-        assertThat(driver.getTitle()).isEqualTo("Success");
-    }
-
     @Test
     void whenDocumentUploadFailsThenThereShouldBeAnError() throws InterruptedException {
         doThrow(new InterruptedException())

--- a/src/test/java/org/codeforamerica/shiba/pages/journeys/DocumentsTest.java
+++ b/src/test/java/org/codeforamerica/shiba/pages/journeys/DocumentsTest.java
@@ -51,14 +51,6 @@ public class DocumentsTest extends JourneyTest {
     }
 
     @Test
-    void showFileTypeErrorMessageWhenClientHasUploadedInvalidFileType() {
-        getToDocumentUploadScreen();
-        driver.executeScript("$('#document-upload').get(0).dropzone.addFile({name: 'testFile.xyz', size: 1000, type: 'not-an-image'})");
-
-        assertThat(driver.findElementByClassName("text--error").getText()).contains("You can't upload files of this type");
-    }
-
-    @Test
     void shouldUpdateFileCountWhenRemoveIsClickedIfAnUploadHasAnError() {
         getToDocumentUploadScreen();
         uploadJpgFile();

--- a/src/test/java/org/codeforamerica/shiba/pages/journeys/DocumentsTest.java
+++ b/src/test/java/org/codeforamerica/shiba/pages/journeys/DocumentsTest.java
@@ -52,66 +52,6 @@ public class DocumentsTest extends JourneyTest {
     }
 
     @Test
-    void shouldDisplayDocumentRecommendationsForHousehold() {
-        // TODO move this test's assertions to DocRecommendationMessageServiceTest
-        completeFlowFromLandingPageThroughReviewInfo(List.of(PROGRAM_CCAP), smartyStreetClient);
-        testPage.clickLink("This looks correct");
-        testPage.enter("addHouseholdMembers", YES.getDisplayValue());
-        testPage.clickContinue();
-        fillOutHousemateInfo(PROGRAM_SNAP);
-        testPage.clickContinue();
-        testPage.clickButton("Yes, that's everyone");
-        testPage.clickContinue();
-        testPage.enter("isPreparingMealsTogether", YES.getDisplayValue());
-        testPage.enter("livingSituation", "None of these");
-        testPage.clickContinue();
-        testPage.enter("goingToSchool", NO.getDisplayValue());
-        testPage.enter("isPregnant", NO.getDisplayValue());
-        testPage.enter("migrantOrSeasonalFarmWorker", NO.getDisplayValue());
-        testPage.enter("isUsCitizen", YES.getDisplayValue());
-        testPage.enter("hasDisability", NO.getDisplayValue());
-
-        // Recommend proof of job loss
-        testPage.enter("hasWorkSituation", YES.getDisplayValue());
-        testPage.clickContinue();
-        // Recommend proof of income
-        testPage.enter("areYouWorking", YES.getDisplayValue());
-        testPage.clickButton("Add a job");
-        testPage.enter("whoseJobIsIt", "householdMemberFirstName householdMemberLastName");
-        testPage.clickContinue();
-        testPage.enter("employersName", "some employer");
-        testPage.clickContinue();
-        testPage.enter("selfEmployment", YES.getDisplayValue());
-
-        testPage.enter("paidByTheHour", YES.getDisplayValue());
-        testPage.enter("hourlyWage", "1");
-        testPage.clickContinue();
-        testPage.enter("hoursAWeek", "30");
-        testPage.clickContinue();
-        testPage.clickButton("No, that's it.");
-        testPage.enter("currentlyLookingForJob", NO.getDisplayValue());
-
-        testPage.clickContinue();
-        testPage.enter("unearnedIncome", "None of the above");
-        testPage.clickContinue();
-        testPage.enter("unearnedIncomeCcap", "None of the above");
-        testPage.clickContinue();
-        testPage.enter("earnLessMoneyThisMonth", NO.getDisplayValue());
-        testPage.clickContinue();
-        testPage.clickContinue();
-        // Recommend proof of shelter
-        testPage.enter("homeExpenses", "Rent");
-        testPage.clickContinue();
-
-        navigateTo("signThisApplication");
-        testPage.enter("applicantSignature", "some name");
-        testPage.clickButton("Submit");
-
-        assertThat(driver.getTitle()).isEqualTo("Document Recommendation");
-        assertThat(driver.findElementsByClassName("success-icons")).hasSize(3);
-    }
-
-    @Test
     void whenDocumentUploadFailsThenThereShouldBeAnError() throws InterruptedException {
         doThrow(new InterruptedException())
                 .when(documentRepositoryService).uploadConcurrently(any(String.class), any(MultipartFile.class));

--- a/src/test/java/org/codeforamerica/shiba/pages/journeys/JourneyTest.java
+++ b/src/test/java/org/codeforamerica/shiba/pages/journeys/JourneyTest.java
@@ -44,7 +44,7 @@ public abstract class JourneyTest extends AbstractBasePageTest {
     protected Clock clock;
     @MockBean
     protected SmartyStreetClient smartyStreetClient;
-    @MockBean
+    @SpyBean
     protected CombinedDocumentRepositoryService documentRepositoryService;
     @MockBean
     protected PageEventPublisher pageEventPublisher;
@@ -180,5 +180,12 @@ public abstract class JourneyTest extends AbstractBasePageTest {
         assertThat(applicationSubmittedEvent.getFlow()).isEqualTo(flowType);
         assertThat(applicationSubmittedEvent.getApplicationId()).isEqualTo(applicationId);
         assertThat(applicationSubmittedEvent.getLocale()).isEqualTo(ENGLISH);
+    }
+
+    protected void deleteAFile() {
+        testPage.clickLink("delete");
+
+        assertThat(testPage.getTitle()).isEqualTo("Delete a file");
+        testPage.clickButton("Yes, delete the file");
     }
 }


### PR DESCRIPTION
This does not completely remove the E2E tests for document uploads, but it combines most of them and converts most of the others to MockMvc. 

For me this reduces the execution time of DocumentsTest from 2m 35s to 27s, which is a pretty good gain!

We were not using a real documentRepositoryService in our JourneyTests, which is a problem because we want to be sure that functionality continues working. This makes it so we are once again using an actual documentRepositoryService.

Unfortunately, using an actual document repository service causes the accessibility tests to fail. That is something we need to fix, but is out of scope for this PR. [Here's a chore for addressing that](https://www.pivotaltracker.com/n/projects/2441723)