### PR TITLE
Move all journey tests to `journeys` package; remove `newJourneys`

### DIFF
--- a/.github/workflows/run-percy.yml
+++ b/.github/workflows/run-percy.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Run journey test and send to Percy
-      run: percy exec -- ./gradlew clean test --tests org.codeforamerica.shiba.newjourneys.FullFlowJourneyTest.fullApplicationWithDocumentUploads
+      run: percy exec -- ./gradlew clean test --tests org.codeforamerica.shiba.journeys.FullFlowJourneyTest.fullApplicationWithDocumentUploads
       env:
         PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
         S3_BUCKET: ${{ secrets.S3_TEST_BUCKET }}

--- a/src/test/java/org/codeforamerica/shiba/journeys/AccessibilityJourneyTest.java
+++ b/src/test/java/org/codeforamerica/shiba/journeys/AccessibilityJourneyTest.java
@@ -1,4 +1,4 @@
-package org.codeforamerica.shiba.pages.journeys;
+package org.codeforamerica.shiba.journeys;
 
 import com.deque.html.axecore.results.Results;
 import com.deque.html.axecore.results.Rule;
@@ -24,7 +24,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 @Tag("a11y")
-public class AccessibilityJourneyPageTest extends JourneyTest {
+public class AccessibilityJourneyTest extends JourneyTest {
     protected static List<Rule> resultsList = new ArrayList<>();
     protected static Results results;
     protected AccessibilityTestPage testPage;

--- a/src/test/java/org/codeforamerica/shiba/journeys/DocumentUploadJourneyTest.java
+++ b/src/test/java/org/codeforamerica/shiba/journeys/DocumentUploadJourneyTest.java
@@ -1,6 +1,5 @@
-package org.codeforamerica.shiba.newjourneys;
+package org.codeforamerica.shiba.journeys;
 
-import org.codeforamerica.shiba.pages.journeys.JourneyTest;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;

--- a/src/test/java/org/codeforamerica/shiba/journeys/FullFlowJourneyTest.java
+++ b/src/test/java/org/codeforamerica/shiba/journeys/FullFlowJourneyTest.java
@@ -1,7 +1,6 @@
-package org.codeforamerica.shiba.newjourneys;
+package org.codeforamerica.shiba.journeys;
 
 import org.codeforamerica.shiba.TestUtils;
-import org.codeforamerica.shiba.pages.journeys.JourneyTest;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;

--- a/src/test/java/org/codeforamerica/shiba/journeys/JourneyTest.java
+++ b/src/test/java/org/codeforamerica/shiba/journeys/JourneyTest.java
@@ -1,4 +1,4 @@
-package org.codeforamerica.shiba.pages.journeys;
+package org.codeforamerica.shiba.journeys;
 
 import org.apache.pdfbox.pdmodel.interactive.form.PDAcroForm;
 import org.codeforamerica.shiba.AbstractBasePageTest;
@@ -36,7 +36,7 @@ import static org.codeforamerica.shiba.output.Document.CCAP;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
-public abstract class JourneyTest extends AbstractBasePageTest {
+abstract class JourneyTest extends AbstractBasePageTest {
     protected PDAcroForm caf;
     protected PDAcroForm ccap;
 

--- a/src/test/java/org/codeforamerica/shiba/journeys/LaterDocsJourneyTest.java
+++ b/src/test/java/org/codeforamerica/shiba/journeys/LaterDocsJourneyTest.java
@@ -1,7 +1,6 @@
-package org.codeforamerica.shiba.newjourneys;
+package org.codeforamerica.shiba.journeys;
 
 import org.codeforamerica.shiba.pages.config.FeatureFlag;
-import org.codeforamerica.shiba.pages.journeys.JourneyTest;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;

--- a/src/test/java/org/codeforamerica/shiba/journeys/MinimumSnapFlowJourneyTest.java
+++ b/src/test/java/org/codeforamerica/shiba/journeys/MinimumSnapFlowJourneyTest.java
@@ -1,8 +1,7 @@
-package org.codeforamerica.shiba.newjourneys;
+package org.codeforamerica.shiba.journeys;
 
 import org.codeforamerica.shiba.pages.config.FeatureFlag;
 import org.codeforamerica.shiba.pages.enrichment.Address;
-import org.codeforamerica.shiba.pages.journeys.JourneyTest;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;

--- a/src/test/java/org/codeforamerica/shiba/pages/UserJourneyMockMvcTest.java
+++ b/src/test/java/org/codeforamerica/shiba/pages/UserJourneyMockMvcTest.java
@@ -1,4 +1,4 @@
-package org.codeforamerica.shiba.pages.journeys;
+package org.codeforamerica.shiba.pages;
 
 import org.apache.pdfbox.pdmodel.interactive.form.PDAcroForm;
 import org.codeforamerica.shiba.AbstractShibaMockMvcTest;


### PR DESCRIPTION
We have converted all of the old tests that extended `JourneyTest` so we can now consolidate the journey tests into one package