### PR TITLE
Reuse the same chrome session between webdriver tests

### DIFF
--- a/src/test/java/org/codeforamerica/shiba/journeys/FullFlowJourneyTest.java
+++ b/src/test/java/org/codeforamerica/shiba/journeys/FullFlowJourneyTest.java
@@ -319,7 +319,7 @@ public class FullFlowJourneyTest extends JourneyTest {
 
         // Finish uploading docs and download PDFS
         testPage.clickButton("Submit my documents");
-        String applicationId = downloadPdfs(true, true);
+        applicationId = downloadPdfs(true, true);
 
         // CCAP fields
         assertCcapFieldEquals("APPLICATION_ID", applicationId);

--- a/src/test/java/org/codeforamerica/shiba/journeys/JourneyTest.java
+++ b/src/test/java/org/codeforamerica/shiba/journeys/JourneyTest.java
@@ -1,5 +1,6 @@
 package org.codeforamerica.shiba.journeys;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.pdfbox.pdmodel.interactive.form.PDAcroForm;
 import org.codeforamerica.shiba.testutilities.AbstractBasePageTest;
 import org.codeforamerica.shiba.testutilities.TestUtils;
@@ -15,16 +16,20 @@ import org.codeforamerica.shiba.pages.enrichment.smartystreets.SmartyStreetClien
 import org.codeforamerica.shiba.pages.events.ApplicationSubmittedEvent;
 import org.codeforamerica.shiba.pages.events.PageEventPublisher;
 import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.mockito.ArgumentCaptor;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 
+import java.io.File;
 import java.io.IOException;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.Callable;
 
@@ -39,6 +44,7 @@ import static org.mockito.Mockito.*;
 abstract class JourneyTest extends AbstractBasePageTest {
     protected PDAcroForm caf;
     protected PDAcroForm ccap;
+    protected String applicationId;
 
     @MockBean
     protected Clock clock;
@@ -69,6 +75,15 @@ abstract class JourneyTest extends AbstractBasePageTest {
         when(featureFlagConfiguration.get("apply-without-address")).thenReturn(FeatureFlag.OFF);
         caf = null;
         ccap = null;
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (applicationId != null) {
+            Arrays.stream(Objects.requireNonNull(path.toFile().listFiles()))
+                    .filter(file -> file.getName().contains(applicationId))
+                    .forEach(File::delete);
+        }
     }
 
     protected void assertCafFieldEquals(String fieldName, String expectedVal) {

--- a/src/test/java/org/codeforamerica/shiba/journeys/MinimumSnapFlowJourneyTest.java
+++ b/src/test/java/org/codeforamerica/shiba/journeys/MinimumSnapFlowJourneyTest.java
@@ -83,7 +83,7 @@ public class MinimumSnapFlowJourneyTest extends JourneyTest {
         testPage.clickContinue();
 
         // Finish Application
-        String applicationId = signApplicationAndDownloadPdfs(signature, true, false);
+        applicationId = signApplicationAndDownloadPdfs(signature, true, false);
         assertApplicationSubmittedEventWasPublished(applicationId, MINIMUM, 1);
 
         // PDF assertions
@@ -163,7 +163,7 @@ public class MinimumSnapFlowJourneyTest extends JourneyTest {
         testPage.clickContinue();
 
         // Finish Application
-        String applicationId = signApplicationAndDownloadPdfs(signature, true, false);
+        applicationId = signApplicationAndDownloadPdfs(signature, true, false);
         assertApplicationSubmittedEventWasPublished(applicationId, EXPEDITED, 1);
 
         // PDF assertions

--- a/src/test/java/org/codeforamerica/shiba/pages/LocalePreferenceSelectionTest.java
+++ b/src/test/java/org/codeforamerica/shiba/pages/LocalePreferenceSelectionTest.java
@@ -1,6 +1,7 @@
 package org.codeforamerica.shiba.pages;
 
 import org.codeforamerica.shiba.testutilities.AbstractBasePageTest;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
@@ -17,6 +18,11 @@ public class LocalePreferenceSelectionTest extends AbstractBasePageTest {
     protected void setUp() throws IOException {
         super.setUp();
         driver.navigate().to(baseUrl);
+    }
+
+    @AfterEach
+    void tearDown() {
+        testPage.selectFromDropdown("locales", "English");
     }
 
     @Test

--- a/src/test/java/org/codeforamerica/shiba/testutilities/SeleniumFactory.java
+++ b/src/test/java/org/codeforamerica/shiba/testutilities/SeleniumFactory.java
@@ -1,0 +1,54 @@
+package org.codeforamerica.shiba.testutilities;
+
+import io.github.bonigarcia.wdm.WebDriverManager;
+import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.remote.RemoteWebDriver;
+import org.springframework.beans.factory.FactoryBean;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+
+public class SeleniumFactory implements FactoryBean<RemoteWebDriver> {
+    private RemoteWebDriver driver;
+    private final Path tempdir;
+
+    public SeleniumFactory(Path tempdir) {
+        this.tempdir = tempdir;
+    }
+
+    @Override
+    public RemoteWebDriver getObject() {
+        return driver;
+    }
+
+    @Override
+    public Class<RemoteWebDriver> getObjectType() {
+        return RemoteWebDriver.class;
+    }
+
+    @Override
+    public boolean isSingleton() {
+        return true;
+    }
+
+    public void start() throws IOException {
+        WebDriverManager.chromedriver().setup();
+        ChromeOptions options = new ChromeOptions();
+        HashMap<String, Object> chromePrefs = new HashMap<>();
+        chromePrefs.put("download.default_directory", tempdir.toString());
+        options.setExperimentalOption("prefs", chromePrefs);
+        options.addArguments("--window-size=1280,1600");
+        options.addArguments("--headless");
+        driver = new ChromeDriver(options);
+    }
+
+    public void stop() {
+        if (driver != null) {
+            driver.close();
+            driver.quit();
+        }
+    }
+}

--- a/src/test/java/org/codeforamerica/shiba/testutilities/WebDriverConfiguration.java
+++ b/src/test/java/org/codeforamerica/shiba/testutilities/WebDriverConfiguration.java
@@ -1,0 +1,27 @@
+package org.codeforamerica.shiba.testutilities;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Scope;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+@TestConfiguration
+public class WebDriverConfiguration {
+    @Autowired
+    private Path tempdir;
+
+    @Bean(initMethod = "start", destroyMethod = "stop")
+    @Scope("singleton")
+    public SeleniumFactory seleniumComponent() {
+        return new SeleniumFactory(tempdir);
+    }
+
+    @Bean
+    public Path tempDir() throws IOException {
+        return Files.createTempDirectory("");
+    }
+}


### PR DESCRIPTION
Instead of booting up chrome for each individual test. The hope is that this will reduce the test time for our Minnesota engineer friends.