### PR TITLE
Use glassfish for JAXB instead of com.sun.xml.bind:jaxb-xjc.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -114,10 +114,15 @@ dependencies {
     implementation 'net.logstash.logback:logstash-logback-encoder:6.6'
     implementation 'net.javacrumbs.shedlock:shedlock-spring:4.25.0'
     implementation 'net.javacrumbs.shedlock:shedlock-provider-jdbc-template:4.25.0'
+    implementation 'com.sun.istack:istack-commons-runtime:3.0.12'
 
     implementation 'org.springframework.ws:spring-ws-core'
     implementation(files(genJaxb.classesDir).builtBy(genJaxb))
-    jaxb "com.sun.xml.bind:jaxb-xjc:2.3.4"
+    jaxb(
+            'org.glassfish.jaxb:jaxb-runtime',
+            'org.glassfish.jaxb:jaxb-xjc',
+            'org.glassfish.jaxb:jaxb-jxc'
+    )
 
     testCompileOnly 'org.projectlombok:lombok'
     testAnnotationProcessor 'org.projectlombok:lombok'


### PR DESCRIPTION
- "com.sun.xml.bind:jaxb-xjc:2.3.4" is described as the "old JAXB runtime". Source: https://mvnrepository.com/artifact/com.sun.xml.bind/jaxb-impl/2.2.11
- This stackoverflow post explains what artifacts should be used now. The answer is glassfish jaxb https://stackoverflow.com/questions/26413431/which-artifacts-should-i-use-for-jaxb-ri-in-my-maven-project
- We can get glassfish versions from the spring-boot-bom, meaning we will no longer get jaxb update PRs!
- Updating this will make https://github.com/codeforamerica/shiba/pull/340 irrelevant

[#179330988]