### PR TITLE
Avoid NullPointerException if client tries to go to a nonexistant page

### DIFF
--- a/src/main/java/org/codeforamerica/shiba/pages/PageController.java
+++ b/src/main/java/org/codeforamerica/shiba/pages/PageController.java
@@ -233,9 +233,12 @@ public class PageController {
               landmarkPagesConfiguration.getLandingPages().get(0)));
     }
 
-    response.addHeader("Cache-Control", "no-store");
-
     var pageWorkflowConfig = applicationConfiguration.getPageWorkflow(pageName);
+    if (pageWorkflowConfig == null) {
+      return new ModelAndView("redirect:/error");
+    }
+
+    response.addHeader("Cache-Control", "no-store");
     if (missingRequiredSubworkflows(pageWorkflowConfig)) {
       return new ModelAndView(
           "redirect:/pages/" + pageWorkflowConfig.getDataMissingRedirect());
@@ -311,8 +314,8 @@ public class PageController {
   }
 
   private boolean missingRequiredSubworkflows(PageWorkflowConfiguration pageWorkflow) {
-    return pageWorkflow.getPageConfiguration().getInputs().isEmpty() && !applicationData
-        .hasRequiredSubworkflows(pageWorkflow.getDatasources());
+    return pageWorkflow.getPageConfiguration().getInputs().isEmpty() &&
+        !applicationData.hasRequiredSubworkflows(pageWorkflow.getDatasources());
   }
 
   private boolean isStartPageForGroup(@PathVariable String pageName, String groupName) {

--- a/src/test/java/org/codeforamerica/shiba/pages/PageControllerTest.java
+++ b/src/test/java/org/codeforamerica/shiba/pages/PageControllerTest.java
@@ -500,4 +500,19 @@ class PageControllerTest {
     verify(applicationRepository).updateStatus(application.getId(), CCAP, IN_PROGRESS);
     verify(applicationRepository, never()).updateStatus(application.getId(), CAF, IN_PROGRESS);
   }
+
+  @Test
+  void shouldRedirectToErrorPageWhenAnInvalidPageIsRequested() throws Exception {
+    applicationData.setStartTimeOnce(Instant.now());
+    String applicationId = "someId";
+    applicationData.setId(applicationId);
+    Application application = Application.builder()
+        .id(applicationId)
+        .applicationData(applicationData)
+        .build();
+    when(applicationRepository.getNextId()).thenReturn(applicationId);
+    when(applicationFactory.newApplication(applicationData)).thenReturn(application);
+
+    mockMvc.perform(get("/pages/doesNotExist")).andExpect(redirectedUrl("/error"));
+  }
 }


### PR DESCRIPTION
- I'm sick of seeing these errors in sentry
- Now if a user requests a nonexistant page, they will just be redirected to the error page.
- There should be no functional change here from a user standpoint

[#179092595]