### PR TITLE
Adding new status table migration

### DIFF
--- a/src/main/resources/db/migration/V33__create-application-status-table.sql
+++ b/src/main/resources/db/migration/V33__create-application-status-table.sql
@@ -1,0 +1,13 @@
+CREATE TABLE application_status
+(
+    id                  VARCHAR NOT NULL PRIMARY KEY,
+    application_id      VARCHAR,
+    document_type       VARCHAR,
+    routing_destination VARCHAR,
+    status              VARCHAR,
+    created_at          TIMESTAMP WITHOUT TIME ZONE,
+    updated_at          TIMESTAMP WITHOUT TIME ZONE
+);
+
+CREATE INDEX application_status_index
+    ON application_status (application_id, document_type, routing_destination);

--- a/src/main/resources/db/migration/V33__create-application-status-table.sql
+++ b/src/main/resources/db/migration/V33__create-application-status-table.sql
@@ -1,13 +1,26 @@
 CREATE TABLE application_status
 (
-    id                  VARCHAR NOT NULL PRIMARY KEY,
     application_id      VARCHAR,
     document_type       VARCHAR,
     routing_destination VARCHAR,
     status              VARCHAR,
-    created_at          TIMESTAMP WITHOUT TIME ZONE,
-    updated_at          TIMESTAMP WITHOUT TIME ZONE
+    created_at          TIMESTAMP WITHOUT TIME ZONE DEFAULT NOW(),
+    updated_at          TIMESTAMP WITHOUT TIME ZONE DEFAULT NOW()
 );
 
 CREATE INDEX application_status_index
     ON application_status (application_id, document_type, routing_destination);
+
+-- See V32 migration
+-- Previously we were making separate db calls for updating each document status, and we were making
+--  many calls to update the `updated_at` column on every post request.
+-- Now we update all of the document statuses during `applicationRepository.save()` and the
+--  `updated_at` column gets updated via a db trigger whenever we save to the `applications` table.
+CREATE TRIGGER set_timestamp_on_application_status
+    BEFORE UPDATE
+    ON application_status
+    FOR EACH ROW
+EXECUTE PROCEDURE trigger_set_timestamp();
+
+-- Remove deprecated table
+DROP TABLE IF EXISTS research;


### PR DESCRIPTION
- Not adding fk reference to application_id for now to avoid complications with that constraint. We can add it later if needed
- Setting `WITHOUT TIME ZONE` for timestamps to match completed_at in applications table
- Not including any tests with this change since it's just adding an unused table. Tests can be added with the read/write changes
- Reusing TRIGGER from previous migration for updating `updated_at` column
- Dropping deprecated research table

[#180018044]