### PR TITLE
Write to application status table

### DIFF
--- a/src/main/java/db/migration/V34__BackfillApplicationStatus.java
+++ b/src/main/java/db/migration/V34__BackfillApplicationStatus.java
@@ -1,0 +1,80 @@
+package db.migration;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.codeforamerica.shiba.pages.data.ApplicationData;
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.datasource.SingleConnectionDataSource;
+
+/**
+ * 1. Get applications with non-null statuses
+ * <p>
+ * 2. Backfill rows in application_status
+ */
+public class V34__BackfillApplicationStatus extends BaseJavaMigration {
+
+  public static final String BASE_QUERY = """
+      SELECT id, %s as status, application_data, county
+      FROM applications
+      WHERE %s IS NOT NULL
+      AND %s != 'null'""";
+  ObjectMapper objectMapper;
+  JdbcTemplate jdbcTemplate;
+
+  public void migrate(Context context) throws GeneralSecurityException, IOException {
+    jdbcTemplate = new JdbcTemplate(new SingleConnectionDataSource(context.getConnection(), true));
+    objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
+    objectMapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+
+    insertStatuses("caf_application_status", "CAF");
+    insertStatuses("ccap_application_status", "CCAP");
+    insertStatuses("uploaded_documents_status", "UPLOADED_DOC");
+  }
+
+  private void insertStatuses(String statusColumnName, String documentType) {
+    List<Map<String, Object>> parametersForInsert = new ArrayList<>();
+
+    String query = String.format(BASE_QUERY, statusColumnName, statusColumnName, statusColumnName);
+    List<Map<String, Object>> queryResults = jdbcTemplate.queryForList(query);
+    for (Map<String, Object> rs : queryResults) {
+      try {
+        // Default to county if routing destinations not provided
+        ApplicationData applicationData =
+            objectMapper.readValue(rs.get("application_data").toString(), ApplicationData.class);
+        List<String> routingDestinationNames = applicationData.getRoutingDestinationNames();
+        if (routingDestinationNames == null || routingDestinationNames.isEmpty()) {
+          routingDestinationNames = List.of(rs.get("county").toString());
+        }
+
+        for (String routingDestination : routingDestinationNames) {
+          parametersForInsert.add(Map.of("application_id", rs.get("id"),
+              "status", rs.get("status"),
+              "document_type", documentType,
+              "routing_destination", routingDestination));
+        }
+      } catch (Exception e) {
+        System.out.println("Unable to migrate id=" + rs.get("id"));
+        e.printStackTrace();
+      }
+    }
+
+    NamedParameterJdbcTemplate namedParameterJdbcTemplate =
+        new NamedParameterJdbcTemplate(jdbcTemplate);
+    for (Map<String, Object> parameter : parametersForInsert) {
+      namedParameterJdbcTemplate.update("""
+          INSERT INTO application_status (application_id, document_type, routing_destination, status)
+          VALUES (:application_id, :document_type, :routing_destination, :status)
+          ON CONFLICT DO NOTHING""", parameter);
+    }
+  }
+
+}

--- a/src/main/java/org/codeforamerica/shiba/ResubmissionService.java
+++ b/src/main/java/org/codeforamerica/shiba/ResubmissionService.java
@@ -73,7 +73,7 @@ public class ResubmissionService {
       log.info("Attempting to resubmit %s(s) for application id %s to emails %s".formatted(
           document.name(), id, recipientEmails));
       try {
-        if (document.equals(UPLOADED_DOC)) {
+        if (document == UPLOADED_DOC) {
           resubmitUploadedDocumentsForApplication(document, application, recipientEmails);
         } else {
           var applicationFile = pdfGenerator.generate(application, document, CASEWORKER);
@@ -81,10 +81,12 @@ public class ResubmissionService {
               eml -> emailClient.resubmitFailedEmail(eml, document, applicationFile, application));
         }
         applicationRepository.updateStatus(id, document, DELIVERED);
+        applicationRepository.updateStatus(id, document, routingDestinations, DELIVERED);
         log.info("Resubmitted %s(s) for application id %s".formatted(document.name(), id));
       } catch (Exception e) {
         log.error("Failed to resubmit application %s via email".formatted(id), e);
         applicationRepository.updateStatus(id, document, RESUBMISSION_FAILED);
+        applicationRepository.updateStatus(id, document, routingDestinations, RESUBMISSION_FAILED);
       }
     }));
     MDC.clear();

--- a/src/main/java/org/codeforamerica/shiba/ResubmissionService.java
+++ b/src/main/java/org/codeforamerica/shiba/ResubmissionService.java
@@ -80,12 +80,10 @@ public class ResubmissionService {
           recipientEmails.forEach(
               eml -> emailClient.resubmitFailedEmail(eml, document, applicationFile, application));
         }
-        applicationRepository.updateStatus(id, document, DELIVERED);
         applicationRepository.updateStatus(id, document, routingDestinations, DELIVERED);
         log.info("Resubmitted %s(s) for application id %s".formatted(document.name(), id));
       } catch (Exception e) {
         log.error("Failed to resubmit application %s via email".formatted(id), e);
-        applicationRepository.updateStatus(id, document, RESUBMISSION_FAILED);
         applicationRepository.updateStatus(id, document, routingDestinations, RESUBMISSION_FAILED);
       }
     }));

--- a/src/main/java/org/codeforamerica/shiba/application/Application.java
+++ b/src/main/java/org/codeforamerica/shiba/application/Application.java
@@ -70,7 +70,7 @@ public class Application {
     return getApplicationStatus(Document.UPLOADED_DOC);
   }
 
-  private Status getApplicationStatus(Document document) {
+  public Status getApplicationStatus(Document document) {
     if (applicationStatuses != null) {
       return applicationStatuses.stream()
           .filter(appStatus -> appStatus.getDocumentType() == document).findFirst()

--- a/src/main/java/org/codeforamerica/shiba/application/Application.java
+++ b/src/main/java/org/codeforamerica/shiba/application/Application.java
@@ -3,10 +3,12 @@ package org.codeforamerica.shiba.application;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.ZonedDateTime;
+import java.util.List;
 import java.util.Optional;
 import lombok.Builder;
 import lombok.Data;
 import org.codeforamerica.shiba.County;
+import org.codeforamerica.shiba.output.Document;
 import org.codeforamerica.shiba.pages.Feedback;
 import org.codeforamerica.shiba.pages.Sentiment;
 import org.codeforamerica.shiba.pages.data.ApplicationData;
@@ -25,11 +27,8 @@ public class Application {
   private FlowType flow;
   private Sentiment sentiment;
   private String feedback;
-  private Status cafApplicationStatus;
-  private Status ccapApplicationStatus;
-  private Status certainPopsApplicationStatus;
-  private Status uploadedDocumentApplicationStatus;
   private Status docUploadEmailStatus;
+  private List<ApplicationStatus> applicationStatuses;
 
   public Application addFeedback(Feedback feedback) {
     var sentiment = Optional.ofNullable(feedback.sentiment()).orElse(this.sentiment);
@@ -45,16 +44,38 @@ public class Application {
         flow,
         sentiment,
         feedbackText,
-        cafApplicationStatus,
-        ccapApplicationStatus,
-        certainPopsApplicationStatus,
-        uploadedDocumentApplicationStatus,
-        docUploadEmailStatus
+        docUploadEmailStatus,
+        applicationStatuses
     );
   }
 
   public void setCompletedAtTime(Clock clock) {
     completedAt = ZonedDateTime.now(clock);
     setTimeToComplete(Duration.between(applicationData.getStartTime(), completedAt));
+  }
+
+  public Status getCafApplicationStatus() {
+    return getApplicationStatus(Document.CAF);
+  }
+
+  public Status getCcapApplicationStatus() {
+    return getApplicationStatus(Document.CCAP);
+  }
+
+  public Status getCertainPopsApplicationStatus() {
+    return getApplicationStatus(Document.CERTAIN_POPS);
+  }
+
+  public Status getUploadDocumentStatus() {
+    return getApplicationStatus(Document.UPLOADED_DOC);
+  }
+
+  private Status getApplicationStatus(Document document) {
+    if (applicationStatuses != null) {
+      return applicationStatuses.stream()
+          .filter(appStatus -> appStatus.getDocumentType() == document).findFirst()
+          .map(ApplicationStatus::getStatus).orElse(null);
+    }
+    return null;
   }
 }

--- a/src/main/java/org/codeforamerica/shiba/application/ApplicationRepository.java
+++ b/src/main/java/org/codeforamerica/shiba/application/ApplicationRepository.java
@@ -174,6 +174,7 @@ public class ApplicationRepository {
    * Try to update existing status - if it's not found, add a new one.
    */
   public void updateStatus(String id, Document document, String routingDestination, Status status) {
+    updateStatus(id, document, status);
     if (document == null || routingDestination == null) {
       return;
     }

--- a/src/main/java/org/codeforamerica/shiba/application/ApplicationRepository.java
+++ b/src/main/java/org/codeforamerica/shiba/application/ApplicationRepository.java
@@ -20,7 +20,10 @@ import java.util.Map;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.codeforamerica.shiba.County;
+import org.codeforamerica.shiba.application.parsers.DocumentListParser;
+import org.codeforamerica.shiba.mnit.RoutingDestination;
 import org.codeforamerica.shiba.output.Document;
+import org.codeforamerica.shiba.pages.RoutingDecisionService;
 import org.codeforamerica.shiba.pages.Sentiment;
 import org.codeforamerica.shiba.pages.data.ApplicationData;
 import org.jetbrains.annotations.NotNull;
@@ -142,6 +145,69 @@ public class ApplicationRepository {
         .orElse(null);
   }
 
+  public void updateStatusToInProgress(Application application,
+      RoutingDecisionService routingDecisionService) {
+    List<Document> documents = DocumentListParser.parse(application.getApplicationData());
+
+    for (Document document : documents) {
+      List<RoutingDestination> routingDestinations = routingDecisionService.getRoutingDestinations(
+          application.getApplicationData(), document);
+      Status status = application.getApplicationStatus(document);
+      if (status != DELIVERED) {
+        updateStatus(application.getId(), document, routingDestinations, IN_PROGRESS);
+      }
+    }
+  }
+
+  public void updateStatus(String id, Document document,
+      List<RoutingDestination> routingDestinations, Status status) {
+    routingDestinations.forEach(
+        routingDestination -> updateStatus(id, document, routingDestination.getName(), status));
+  }
+
+  public void updateStatus(String id, Document document, RoutingDestination routingDestination,
+      Status status) {
+    updateStatus(id, document, routingDestination.getName(), status);
+  }
+
+  /**
+   * Try to update existing status - if it's not found, add a new one.
+   */
+  public void updateStatus(String id, Document document, String routingDestination, Status status) {
+    if (document == null || routingDestination == null) {
+      return;
+    }
+
+    String updateStatement = """
+        UPDATE application_status SET status = :status WHERE application_id = :application_id
+        AND document_type = :document_type AND routing_destination = :routing_destination
+        """;
+
+    Map<String, Object> parameters = new HashMap<>();
+    parameters.put("application_id", id);
+    parameters.put("status", status.toString());
+    parameters.put("document_type", document.name());
+    parameters.put("routing_destination", routingDestination);
+
+    var namedParameterJdbcTemplate = new NamedParameterJdbcTemplate(jdbcTemplate);
+
+    int rowCount = namedParameterJdbcTemplate.update(updateStatement, parameters);
+    if (rowCount == 0) {
+      // Not found, add a new entry
+      String insertStatement = """
+          INSERT INTO application_status (application_id, status, document_type, routing_destination)
+          VALUES (:application_id, :status, :document_type, :routing_destination)
+          """;
+      rowCount = namedParameterJdbcTemplate.update(insertStatement, parameters);
+    }
+
+    if (rowCount != 0) {
+      logStatusUpdate(id, document, routingDestination, status);
+    }
+
+  }
+
+  @Deprecated
   public void updateStatus(String id, Document document, Status status) {
     Map<String, Object> parameters = Map.of(
         "status", status.toString(),
@@ -178,6 +244,22 @@ public class ApplicationRepository {
     }
 
     final String msg = String.format("%s #%s has been updated to %s", document, id, status);
+    switch (status) {
+      case DELIVERY_FAILED, RESUBMISSION_FAILED -> log.error(msg);
+      default -> log.info(msg);
+    }
+  }
+
+  private void logStatusUpdate(String id, Document document, String routingDestination,
+      Status status) {
+    if (status == null) {
+      log.info(String.format("%s to %s #%s application status has been updated to null", document,
+          routingDestination, id));
+      return;
+    }
+
+    final String msg = String.format("%s to %s #%s has been updated to %s", document,
+        routingDestination, id, status);
     switch (status) {
       case DELIVERY_FAILED, RESUBMISSION_FAILED -> log.error(msg);
       default -> log.info(msg);

--- a/src/main/java/org/codeforamerica/shiba/application/ApplicationRepository.java
+++ b/src/main/java/org/codeforamerica/shiba/application/ApplicationRepository.java
@@ -8,6 +8,8 @@ import static org.codeforamerica.shiba.output.Document.CERTAIN_POPS;
 import static org.codeforamerica.shiba.output.Document.UPLOADED_DOC;
 
 import java.security.SecureRandom;
+import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.time.Duration;
 import java.time.ZoneOffset;
@@ -265,26 +267,32 @@ public class ApplicationRepository {
             .flow(Optional.ofNullable(resultSet.getString("flow"))
                 .map(FlowType::valueOf)
                 .orElse(null))
-            .cafApplicationStatus(
-                Optional.ofNullable(resultSet.getString("caf_application_status"))
-                    .map(Status::valueFor)
-                    .orElse(null))
-            .ccapApplicationStatus(
-                Optional.ofNullable(resultSet.getString("ccap_application_status"))
-                    .map(Status::valueFor)
-                    .orElse(null))
-            .certainPopsApplicationStatus(
-                Optional.ofNullable(resultSet.getString("certain_pops_application_status"))
-                    .map(Status::valueFor)
-                    .orElse(null))
-            .uploadedDocumentApplicationStatus(
-                Optional.ofNullable(resultSet.getString("uploaded_documents_status"))
-                    .map(Status::valueFor)
-                    .orElse(null))
+            .applicationStatuses(List.of(
+                applicationStatusMapper("caf_application_status", resultSet),
+                applicationStatusMapper("ccap_application_status", resultSet),
+                applicationStatusMapper("certain_pops_application_status", resultSet),
+                applicationStatusMapper("uploaded_documents_status", resultSet)
+            ))
             .docUploadEmailStatus(
                 Optional.ofNullable(resultSet.getString("doc_upload_email_status"))
                     .map(Status::valueFor)
                     .orElse(null))
             .build();
+  }
+
+  private ApplicationStatus applicationStatusMapper(String column, ResultSet resultSet)
+      throws SQLException {
+    Status status = Optional.ofNullable(resultSet.getString(column))
+        .map(Status::valueFor)
+        .orElse(null);
+
+    return switch (column) {
+      case "caf_application_status" -> new ApplicationStatus(CAF, status);
+      case "ccap_application_status" -> new ApplicationStatus(CCAP, status);
+      case "certain_pops_application_status" -> new ApplicationStatus(CERTAIN_POPS, status);
+      case "uploaded_documents_status" -> new ApplicationStatus(UPLOADED_DOC, status);
+      default -> null;
+    };
+
   }
 }

--- a/src/main/java/org/codeforamerica/shiba/application/ApplicationStatus.java
+++ b/src/main/java/org/codeforamerica/shiba/application/ApplicationStatus.java
@@ -1,0 +1,13 @@
+package org.codeforamerica.shiba.application;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import org.codeforamerica.shiba.output.Document;
+
+@Data
+@AllArgsConstructor
+public class ApplicationStatus {
+
+  private Document documentType;
+  private Status status;
+}

--- a/src/main/java/org/codeforamerica/shiba/mnit/AlfrescoWebServiceClient.java
+++ b/src/main/java/org/codeforamerica/shiba/mnit/AlfrescoWebServiceClient.java
@@ -126,7 +126,6 @@ public class AlfrescoWebServiceClient {
             flowType);
       }
     });
-    applicationRepository.updateStatus(applicationNumber, applicationDocument, DELIVERED);
     applicationRepository.updateStatus(applicationNumber, applicationDocument, routingDestination,
         DELIVERED);
   }
@@ -136,7 +135,6 @@ public class AlfrescoWebServiceClient {
   public void logErrorToSentry(Exception e, ApplicationFile applicationFile,
       RoutingDestination routingDestination,
       String applicationNumber, Document applicationDocument, FlowType flowType) {
-    applicationRepository.updateStatus(applicationNumber, applicationDocument, DELIVERY_FAILED);
     applicationRepository.updateStatus(applicationNumber, applicationDocument, routingDestination,
         DELIVERY_FAILED);
     log.error("Application failed to send: " + applicationFile.getFileName(), e);

--- a/src/main/java/org/codeforamerica/shiba/mnit/AlfrescoWebServiceClient.java
+++ b/src/main/java/org/codeforamerica/shiba/mnit/AlfrescoWebServiceClient.java
@@ -17,12 +17,20 @@ import java.util.List;
 import javax.activation.DataHandler;
 import javax.mail.util.ByteArrayDataSource;
 import javax.xml.namespace.QName;
-import javax.xml.soap.*;
+import javax.xml.soap.SOAPElement;
+import javax.xml.soap.SOAPException;
+import javax.xml.soap.SOAPHeader;
+import javax.xml.soap.SOAPHeaderElement;
+import javax.xml.soap.SOAPMessage;
 import lombok.extern.slf4j.Slf4j;
 import org.codeforamerica.shiba.CountyMap;
 import org.codeforamerica.shiba.application.ApplicationRepository;
 import org.codeforamerica.shiba.application.FlowType;
-import org.codeforamerica.shiba.esbwsdl.*;
+import org.codeforamerica.shiba.esbwsdl.CmisContentStreamType;
+import org.codeforamerica.shiba.esbwsdl.CmisPropertiesType;
+import org.codeforamerica.shiba.esbwsdl.CmisProperty;
+import org.codeforamerica.shiba.esbwsdl.CmisPropertyString;
+import org.codeforamerica.shiba.esbwsdl.CreateDocument;
 import org.codeforamerica.shiba.output.ApplicationFile;
 import org.codeforamerica.shiba.output.Document;
 import org.jetbrains.annotations.NotNull;
@@ -119,6 +127,8 @@ public class AlfrescoWebServiceClient {
       }
     });
     applicationRepository.updateStatus(applicationNumber, applicationDocument, DELIVERED);
+    applicationRepository.updateStatus(applicationNumber, applicationDocument, routingDestination,
+        DELIVERED);
   }
 
   // Recover method has to have the same arguments at the retryable
@@ -127,6 +137,8 @@ public class AlfrescoWebServiceClient {
       RoutingDestination routingDestination,
       String applicationNumber, Document applicationDocument, FlowType flowType) {
     applicationRepository.updateStatus(applicationNumber, applicationDocument, DELIVERY_FAILED);
+    applicationRepository.updateStatus(applicationNumber, applicationDocument, routingDestination,
+        DELIVERY_FAILED);
     log.error("Application failed to send: " + applicationFile.getFileName(), e);
   }
 

--- a/src/main/java/org/codeforamerica/shiba/mnit/FilenetWebServiceClient.java
+++ b/src/main/java/org/codeforamerica/shiba/mnit/FilenetWebServiceClient.java
@@ -173,6 +173,8 @@ public class FilenetWebServiceClient {
     }
     
     applicationRepository.updateStatus(applicationNumber, applicationDocument, DELIVERED);
+    applicationRepository.updateStatus(applicationNumber, applicationDocument, routingDestination,
+        DELIVERED);
   }
 
   @Recover
@@ -180,6 +182,8 @@ public class FilenetWebServiceClient {
       RoutingDestination routingDestination,
       String applicationNumber, Document applicationDocument, FlowType flowType) {
     applicationRepository.updateStatus(applicationNumber, applicationDocument, DELIVERY_FAILED);
+    applicationRepository.updateStatus(applicationNumber, applicationDocument, routingDestination,
+        DELIVERY_FAILED);
     log.error("Application failed to send: " + applicationFile.getFileName(), e);
   }
   

--- a/src/main/java/org/codeforamerica/shiba/mnit/FilenetWebServiceClient.java
+++ b/src/main/java/org/codeforamerica/shiba/mnit/FilenetWebServiceClient.java
@@ -74,10 +74,10 @@ public class FilenetWebServiceClient {
   private final ApplicationRepository applicationRepository;
   private String truststorePassword;
   private String truststore;
-  
+
   @Autowired
   private RestTemplate restTemplate;
-  
+
   @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection")
   public FilenetWebServiceClient(
       @Qualifier("filenetWebServiceTemplate") WebServiceTemplate webServiceTemplate,
@@ -153,7 +153,7 @@ public class FilenetWebServiceClient {
             flowType);
       }
     });
-    
+
     // Now route a copy of the document from Filenet to SFTP
     String idd = response.getObjectId();
     log.info("response from FileNet createDocument: " + idd);
@@ -171,8 +171,7 @@ public class FilenetWebServiceClient {
                 applicationDocument,
                 flowType);
     }
-    
-    applicationRepository.updateStatus(applicationNumber, applicationDocument, DELIVERED);
+
     applicationRepository.updateStatus(applicationNumber, applicationDocument, routingDestination,
         DELIVERED);
   }
@@ -181,12 +180,11 @@ public class FilenetWebServiceClient {
   public void logErrorToSentry(Exception e, ApplicationFile applicationFile,
       RoutingDestination routingDestination,
       String applicationNumber, Document applicationDocument, FlowType flowType) {
-    applicationRepository.updateStatus(applicationNumber, applicationDocument, DELIVERY_FAILED);
     applicationRepository.updateStatus(applicationNumber, applicationDocument, routingDestination,
         DELIVERY_FAILED);
     log.error("Application failed to send: " + applicationFile.getFileName(), e);
   }
-  
+
   private void setPropertiesOnDocument(ApplicationFile applicationFile,
       RoutingDestination routingDestination, String applicationNumber,
       Document applicationDocument, FlowType flowType,
@@ -286,19 +284,19 @@ public class FilenetWebServiceClient {
     }
     return docDescription;
   }
-  
+
   @Bean
   public RestTemplate restTemplate(RestTemplateBuilder builder) throws KeyManagementException, NoSuchAlgorithmException, KeyStoreException, CertificateException, IOException {
-   
+
 	  SSLContext sslContext = SSLContexts.custom()
 			  .loadTrustMaterial(Paths.get(truststore).toFile(), truststorePassword.toCharArray()).build();
-	  SSLConnectionSocketFactory socketFactory = 
+	  SSLConnectionSocketFactory socketFactory =
 			  new SSLConnectionSocketFactory(sslContext, NoopHostnameVerifier.INSTANCE);
 	  HttpClient httpClient = HttpClients.custom()
 			  .setSSLSocketFactory(socketFactory).build();
-	  HttpComponentsClientHttpRequestFactory factory = 
+	  HttpComponentsClientHttpRequestFactory factory =
 			  new HttpComponentsClientHttpRequestFactory(httpClient);
-	  
+
 	  return new RestTemplate(factory);
   }
 }

--- a/src/main/java/org/codeforamerica/shiba/output/MnitDocumentConsumer.java
+++ b/src/main/java/org/codeforamerica/shiba/output/MnitDocumentConsumer.java
@@ -1,6 +1,5 @@
 package org.codeforamerica.shiba.output;
 
-import static org.codeforamerica.shiba.application.Status.DELIVERED;
 import static org.codeforamerica.shiba.application.Status.DELIVERY_FAILED;
 import static org.codeforamerica.shiba.application.Status.SENDING;
 import static org.codeforamerica.shiba.output.Document.CAF;
@@ -121,10 +120,8 @@ public class MnitDocumentConsumer {
   }
 
   public void processUploadedDocuments(Application application) {
-    applicationRepository.updateStatus(application.getId(), UPLOADED_DOC, SENDING);
     List<ApplicationFile> uploadedDocs = prepareUploadedDocsForSending(application);
     sendUploadedDocs(application, uploadedDocs);
-    applicationRepository.updateStatus(application.getId(), UPLOADED_DOC, DELIVERED);
   }
 
   private void sendUploadedDocs(Application application, List<ApplicationFile> uploadedDocs) {
@@ -187,11 +184,9 @@ public class MnitDocumentConsumer {
 
     String id = application.getId();
     try {
-      applicationRepository.updateStatus(id, documentType, SENDING);
       applicationRepository.updateStatus(id, documentType, routingDestination, SENDING);
       sendFile(application, documentType, applicationFile, routingDestination);
     } catch (Exception e) {
-      applicationRepository.updateStatus(id, documentType, DELIVERY_FAILED);
       applicationRepository.updateStatus(id, documentType, routingDestination, DELIVERY_FAILED);
       log.error("Failed to send document %s to recipient %s for application %s with error, "
           .formatted(documentType, routingDestination.getName(), id), e);

--- a/src/main/java/org/codeforamerica/shiba/output/MnitDocumentConsumer.java
+++ b/src/main/java/org/codeforamerica/shiba/output/MnitDocumentConsumer.java
@@ -132,6 +132,9 @@ public class MnitDocumentConsumer {
         .getRoutingDestinations(application.getApplicationData(), UPLOADED_DOC);
 
     for (RoutingDestination routingDestination : routingDestinations) {
+      applicationRepository.updateStatus(application.getId(), UPLOADED_DOC, routingDestination,
+          SENDING);
+
       boolean sendToHennepinViaEmail = featureFlagConfiguration.get(
           "submit-docs-via-email-for-hennepin").isOn();
       boolean isHennepin = routingDestination.getName().equals(County.Hennepin.name());
@@ -185,9 +188,11 @@ public class MnitDocumentConsumer {
     String id = application.getId();
     try {
       applicationRepository.updateStatus(id, documentType, SENDING);
+      applicationRepository.updateStatus(id, documentType, routingDestination, SENDING);
       sendFile(application, documentType, applicationFile, routingDestination);
     } catch (Exception e) {
       applicationRepository.updateStatus(id, documentType, DELIVERY_FAILED);
+      applicationRepository.updateStatus(id, documentType, routingDestination, DELIVERY_FAILED);
       log.error("Failed to send document %s to recipient %s for application %s with error, "
           .formatted(documentType, routingDestination.getName(), id), e);
     }

--- a/src/main/java/org/codeforamerica/shiba/pages/PageController.java
+++ b/src/main/java/org/codeforamerica/shiba/pages/PageController.java
@@ -593,7 +593,6 @@ public class PageController {
   public ResponseEntity<?> upload(@RequestParam("file") MultipartFile file,
       @RequestParam("dataURL") String dataURL,
       @RequestParam("type") String type) throws IOException, InterruptedException {
-    applicationRepository.updateStatus(applicationData.getId(), UPLOADED_DOC, IN_PROGRESS);
     applicationRepository.updateStatus(applicationData.getId(), UPLOADED_DOC,
         routingDecisionService.getRoutingDestinations(applicationData, UPLOADED_DOC),
         IN_PROGRESS);

--- a/src/main/java/org/codeforamerica/shiba/pages/PageController.java
+++ b/src/main/java/org/codeforamerica/shiba/pages/PageController.java
@@ -524,6 +524,7 @@ public class PageController {
 
       Application application = applicationFactory.newApplication(applicationData);
       applicationRepository.save(application);
+      applicationRepository.updateStatusToInProgress(application, routingDecisionService);
       return new ModelAndView(String.format("redirect:/pages/%s/navigation", pageName));
     } else {
       return new ModelAndView("redirect:/pages/" + pageName);
@@ -593,6 +594,9 @@ public class PageController {
       @RequestParam("dataURL") String dataURL,
       @RequestParam("type") String type) throws IOException, InterruptedException {
     applicationRepository.updateStatus(applicationData.getId(), UPLOADED_DOC, IN_PROGRESS);
+    applicationRepository.updateStatus(applicationData.getId(), UPLOADED_DOC,
+        routingDecisionService.getRoutingDestinations(applicationData, UPLOADED_DOC),
+        IN_PROGRESS);
     if (applicationData.getUploadedDocs().size() <= MAX_FILES_UPLOADED &&
         file.getSize() <= uploadDocumentConfiguration.getMaxFilesizeInBytes()) {
       if (type.contains("pdf")) {

--- a/src/main/java/org/codeforamerica/shiba/pages/RoutingDecisionService.java
+++ b/src/main/java/org/codeforamerica/shiba/pages/RoutingDecisionService.java
@@ -164,7 +164,7 @@ public class RoutingDecisionService {
     return selectedTribeName != null
         && tribalNations.get(selectedTribeName) != null
         && (isApplyingForTribalTanf(pagesData) || programs.contains(EA))
-        && !Document.CCAP.equals(document);
+        && Document.CCAP != document;
   }
 }
 

--- a/src/main/java/org/codeforamerica/shiba/pages/emails/MailGunEmailClient.java
+++ b/src/main/java/org/codeforamerica/shiba/pages/emails/MailGunEmailClient.java
@@ -182,7 +182,6 @@ public class MailGunEmailClient implements EmailClient {
           filesToSend, true);
     }
 
-    applicationRepository.updateStatus(application.getId(), UPLOADED_DOC, Status.DELIVERED);
     applicationRepository.updateStatus(application.getId(), UPLOADED_DOC, County.Hennepin.name(),
         Status.DELIVERED);
   }

--- a/src/main/java/org/codeforamerica/shiba/pages/emails/MailGunEmailClient.java
+++ b/src/main/java/org/codeforamerica/shiba/pages/emails/MailGunEmailClient.java
@@ -12,6 +12,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import lombok.extern.slf4j.Slf4j;
+import org.codeforamerica.shiba.County;
 import org.codeforamerica.shiba.application.Application;
 import org.codeforamerica.shiba.application.ApplicationRepository;
 import org.codeforamerica.shiba.application.FlowType;
@@ -182,6 +183,8 @@ public class MailGunEmailClient implements EmailClient {
     }
 
     applicationRepository.updateStatus(application.getId(), UPLOADED_DOC, Status.DELIVERED);
+    applicationRepository.updateStatus(application.getId(), UPLOADED_DOC, County.Hennepin.name(),
+        Status.DELIVERED);
   }
 
   @NotNull

--- a/src/test/java/org/codeforamerica/shiba/ResubmissionServiceTest.java
+++ b/src/test/java/org/codeforamerica/shiba/ResubmissionServiceTest.java
@@ -9,7 +9,12 @@ import static org.codeforamerica.shiba.output.Document.CAF;
 import static org.codeforamerica.shiba.output.Document.CCAP;
 import static org.codeforamerica.shiba.output.Document.UPLOADED_DOC;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -95,7 +100,6 @@ class ResubmissionServiceTest {
     resubmissionService.resubmitFailedApplications();
 
     verify(emailClient).resubmitFailedEmail(DEFAULT_EMAIL, CAF, applicationFile, application);
-    verify(applicationRepository).updateStatus(APP_ID, CAF, Status.DELIVERED);
     verify(applicationRepository).updateStatus(APP_ID, CAF, routingDestinations, Status.DELIVERED);
   }
 
@@ -118,7 +122,6 @@ class ResubmissionServiceTest {
         any());
     verify(emailClient).resubmitFailedEmail(MILLE_LACS_BAND_EMAIL, CAF, applicationFile,
         application);
-    verify(applicationRepository).updateStatus(APP_ID, CAF, Status.DELIVERED);
     verify(applicationRepository).updateStatus(APP_ID, CAF, routingDestinations, Status.DELIVERED);
   }
 
@@ -140,9 +143,7 @@ class ResubmissionServiceTest {
 
     verify(emailClient).resubmitFailedEmail(MILLE_LACS_BAND_EMAIL, CAF, applicationFile,
         application);
-    verify(emailClient).resubmitFailedEmail(ANOKA_EMAIL, CAF, applicationFile,
-        application);
-    verify(applicationRepository).updateStatus(APP_ID, CAF, Status.DELIVERED);
+    verify(emailClient).resubmitFailedEmail(ANOKA_EMAIL, CAF, applicationFile, application);
     verify(applicationRepository).updateStatus(APP_ID, CAF, routingDestinations, Status.DELIVERED);
   }
 
@@ -165,7 +166,6 @@ class ResubmissionServiceTest {
             application);
 
     resubmissionService.resubmitFailedApplications();
-    verify(applicationRepository).updateStatus(APP_ID, CAF, RESUBMISSION_FAILED);
     verify(applicationRepository).updateStatus(APP_ID, CAF, routingDestinations,
         RESUBMISSION_FAILED);
   }
@@ -204,7 +204,6 @@ class ResubmissionServiceTest {
     List<ApplicationFile> applicationFiles = captor.getAllValues();
     assertThat(applicationFiles)
         .containsExactlyElementsOf(List.of(applicationFile1, applicationFile2));
-    verify(applicationRepository).updateStatus(APP_ID, UPLOADED_DOC, Status.DELIVERED);
     verify(applicationRepository).updateStatus(APP_ID, UPLOADED_DOC, routingDestinations,
         Status.DELIVERED);
   }
@@ -246,8 +245,7 @@ class ResubmissionServiceTest {
     var applicationRepositoryDocumentCaptor = ArgumentCaptor.forClass(Document.class);
     verify(applicationRepository, times(2))
         .updateStatus(eq(APP_ID), applicationRepositoryDocumentCaptor.capture(),
-            eq(Status.DELIVERED));
-    verify(applicationRepository).updateStatus(APP_ID, CCAP, routingDestinations, Status.DELIVERED);
+            eq(routingDestinations), eq(Status.DELIVERED));
     assertThat(applicationRepositoryDocumentCaptor.getAllValues())
         .containsExactlyInAnyOrder(UPLOADED_DOC, CCAP);
   }
@@ -277,7 +275,6 @@ class ResubmissionServiceTest {
     verify(emailClient, never())
         .resubmitFailedEmail(DEFAULT_EMAIL, UPLOADED_DOC, uploadedDocWithCoverPageFile,
             application);
-    verify(applicationRepository).updateStatus(APP_ID, UPLOADED_DOC, RESUBMISSION_FAILED);
     verify(applicationRepository).updateStatus(APP_ID, UPLOADED_DOC, routingDestinations,
         RESUBMISSION_FAILED);
   }

--- a/src/test/java/org/codeforamerica/shiba/ResubmissionServiceTest.java
+++ b/src/test/java/org/codeforamerica/shiba/ResubmissionServiceTest.java
@@ -76,7 +76,8 @@ class ResubmissionServiceTest {
         pdfGenerator, routingDecisionService);
 
     routingDestinations = new ArrayList<>();
-    routingDestinations.add(CountyRoutingDestination.builder().email(OLMSTED_EMAIL).build());
+    routingDestinations.add(
+        CountyRoutingDestination.builder().county(Olmsted).email(OLMSTED_EMAIL).build());
     when(routingDecisionService.getRoutingDestinations(any(), any())).thenReturn(
         routingDestinations);
   }
@@ -95,6 +96,7 @@ class ResubmissionServiceTest {
 
     verify(emailClient).resubmitFailedEmail(DEFAULT_EMAIL, CAF, applicationFile, application);
     verify(applicationRepository).updateStatus(APP_ID, CAF, Status.DELIVERED);
+    verify(applicationRepository).updateStatus(APP_ID, CAF, routingDestinations, Status.DELIVERED);
   }
 
   @Test
@@ -117,6 +119,7 @@ class ResubmissionServiceTest {
     verify(emailClient).resubmitFailedEmail(MILLE_LACS_BAND_EMAIL, CAF, applicationFile,
         application);
     verify(applicationRepository).updateStatus(APP_ID, CAF, Status.DELIVERED);
+    verify(applicationRepository).updateStatus(APP_ID, CAF, routingDestinations, Status.DELIVERED);
   }
 
   @Test
@@ -140,6 +143,7 @@ class ResubmissionServiceTest {
     verify(emailClient).resubmitFailedEmail(ANOKA_EMAIL, CAF, applicationFile,
         application);
     verify(applicationRepository).updateStatus(APP_ID, CAF, Status.DELIVERED);
+    verify(applicationRepository).updateStatus(APP_ID, CAF, routingDestinations, Status.DELIVERED);
   }
 
   @Test
@@ -162,6 +166,8 @@ class ResubmissionServiceTest {
 
     resubmissionService.resubmitFailedApplications();
     verify(applicationRepository).updateStatus(APP_ID, CAF, RESUBMISSION_FAILED);
+    verify(applicationRepository).updateStatus(APP_ID, CAF, routingDestinations,
+        RESUBMISSION_FAILED);
   }
 
   @Test
@@ -199,6 +205,8 @@ class ResubmissionServiceTest {
     assertThat(applicationFiles)
         .containsExactlyElementsOf(List.of(applicationFile1, applicationFile2));
     verify(applicationRepository).updateStatus(APP_ID, UPLOADED_DOC, Status.DELIVERED);
+    verify(applicationRepository).updateStatus(APP_ID, UPLOADED_DOC, routingDestinations,
+        Status.DELIVERED);
   }
 
   @Test
@@ -239,6 +247,7 @@ class ResubmissionServiceTest {
     verify(applicationRepository, times(2))
         .updateStatus(eq(APP_ID), applicationRepositoryDocumentCaptor.capture(),
             eq(Status.DELIVERED));
+    verify(applicationRepository).updateStatus(APP_ID, CCAP, routingDestinations, Status.DELIVERED);
     assertThat(applicationRepositoryDocumentCaptor.getAllValues())
         .containsExactlyInAnyOrder(UPLOADED_DOC, CCAP);
   }
@@ -269,5 +278,7 @@ class ResubmissionServiceTest {
         .resubmitFailedEmail(DEFAULT_EMAIL, UPLOADED_DOC, uploadedDocWithCoverPageFile,
             application);
     verify(applicationRepository).updateStatus(APP_ID, UPLOADED_DOC, RESUBMISSION_FAILED);
+    verify(applicationRepository).updateStatus(APP_ID, UPLOADED_DOC, routingDestinations,
+        RESUBMISSION_FAILED);
   }
 }

--- a/src/test/java/org/codeforamerica/shiba/mnit/AlfrescoWebServiceClientTest.java
+++ b/src/test/java/org/codeforamerica/shiba/mnit/AlfrescoWebServiceClientTest.java
@@ -122,6 +122,8 @@ class AlfrescoWebServiceClientTest {
     );
 
     verify(applicationRepository).updateStatus("someId", Document.CAF, DELIVERED);
+    verify(applicationRepository).updateStatus("someId", Document.CAF, routingDestination,
+        DELIVERED);
 
     mockWebServiceServer.verify();
   }

--- a/src/test/java/org/codeforamerica/shiba/mnit/AlfrescoWebServiceClientTest.java
+++ b/src/test/java/org/codeforamerica/shiba/mnit/AlfrescoWebServiceClientTest.java
@@ -10,7 +10,12 @@ import static org.springframework.ws.test.client.RequestMatchers.xpath;
 import static org.springframework.ws.test.client.ResponseCreators.withException;
 import static org.springframework.ws.test.client.ResponseCreators.withSoapEnvelope;
 
-import java.time.*;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.Base64;
 import java.util.Map;
 import javax.xml.soap.SOAPException;
@@ -121,7 +126,6 @@ class AlfrescoWebServiceClientTest {
         routingDestination, "someId", Document.CAF, FlowType.FULL
     );
 
-    verify(applicationRepository).updateStatus("someId", Document.CAF, DELIVERED);
     verify(applicationRepository).updateStatus("someId", Document.CAF, routingDestination,
         DELIVERED);
 

--- a/src/test/java/org/codeforamerica/shiba/mnit/FilenetWebServiceClientTest.java
+++ b/src/test/java/org/codeforamerica/shiba/mnit/FilenetWebServiceClientTest.java
@@ -156,6 +156,8 @@ class FilenetWebServiceClientTest {
     );
 
     verify(applicationRepository).updateStatus("someId", Document.CAF, DELIVERED);
+    verify(applicationRepository).updateStatus("someId", Document.CAF, routingDestination,
+        DELIVERED);
 
     mockWebServiceServer.verify();
   }

--- a/src/test/java/org/codeforamerica/shiba/mnit/FilenetWebServiceClientTest.java
+++ b/src/test/java/org/codeforamerica/shiba/mnit/FilenetWebServiceClientTest.java
@@ -10,7 +10,12 @@ import static org.springframework.ws.test.client.RequestMatchers.xpath;
 import static org.springframework.ws.test.client.ResponseCreators.withException;
 import static org.springframework.ws.test.client.ResponseCreators.withSoapEnvelope;
 
-import java.time.*;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.Map;
 import javax.xml.soap.SOAPException;
 import javax.xml.transform.dom.DOMResult;
@@ -73,10 +78,10 @@ class FilenetWebServiceClientTest {
       "ns2", "http://docs.oasis-open.org/ns/cmis/messaging/200908/",
       "ns3", "http://docs.oasis-open.org/ns/cmis/core/200908/",
       "cmism", "http://docs.oasis-open.org/cmis/CMIS/v1.1/errata01/os/schema/CMIS-Messaging.xsd");
-  private String fileContent = "fileContent";
-  private String fileName = "fileName";
-  private String filenetIdd = "idd_some-filenet-idd";
-  private StringSource successResponse = new StringSource("" +
+  private final String fileContent = "fileContent";
+  private final String fileName = "fileName";
+  private final String filenetIdd = "idd_some-filenet-idd";
+  private final StringSource successResponse = new StringSource("" +
       "<soapenv:Envelope xmlns:soapenv='http://schemas.xmlsoap.org/soap/envelope/'>" +
       "<soapenv:Body>" +
       "<b:createDocumentResponse xmlns:b='http://docs.oasis-open.org/ns/cmis/messaging/200908/'>" +
@@ -86,7 +91,7 @@ class FilenetWebServiceClientTest {
       "</soapenv:Body>" +
       "</soapenv:Envelope>"
   );
-  private String routerResponse = "{\n \"message\" : \"Success\" \n}";
+  private final String routerResponse = "{\n \"message\" : \"Success\" \n}";
 
   @BeforeEach
   void setUp() {
@@ -155,7 +160,6 @@ class FilenetWebServiceClientTest {
         routingDestination, "someId", Document.CAF, FlowType.FULL
     );
 
-    verify(applicationRepository).updateStatus("someId", Document.CAF, DELIVERED);
     verify(applicationRepository).updateStatus("someId", Document.CAF, routingDestination,
         DELIVERED);
 
@@ -241,11 +245,11 @@ class FilenetWebServiceClientTest {
               "//wsse:Security/wsse:UsernameToken/wsse:Password[@Type='http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordText']",
               namespaceContext));
         })
-    .andRespond(withSoapEnvelope(successResponse));
+        .andRespond(withSoapEnvelope(successResponse));
 
     String routerRequest = String.format("%s/%s", routerUrl, filenetIdd);
     Mockito.when(restTemplate.getForObject(routerRequest, String.class)).thenReturn(routerResponse);
-    
+
     filenetWebServiceClient.send(new ApplicationFile(
         "whatever".getBytes(),
         "someFileName"), hennepin, "someId", Document.CAF, FlowType.FULL);

--- a/src/test/java/org/codeforamerica/shiba/output/MnitDocumentConsumerTest.java
+++ b/src/test/java/org/codeforamerica/shiba/output/MnitDocumentConsumerTest.java
@@ -336,6 +336,12 @@ class MnitDocumentConsumerTest {
 
     verify(applicationRepository).updateStatus(application.getId(), CAF, SENDING);
     verify(applicationRepository).updateStatus(application.getId(), CCAP, SENDING);
+
+    CountyRoutingDestination routingDestination = countyMap.get(Hennepin);
+    verify(applicationRepository).updateStatus(application.getId(), CAF, routingDestination,
+        SENDING);
+    verify(applicationRepository).updateStatus(application.getId(), CCAP, routingDestination,
+        SENDING);
   }
 
   @Test
@@ -357,8 +363,15 @@ class MnitDocumentConsumerTest {
     verify(applicationRepository, times(1)).updateStatus(application.getId(), CCAP, SENDING);
     verify(applicationRepository, times(1)).updateStatus(application.getId(), CAF, SENDING);
 
+    CountyRoutingDestination routingDestination = countyMap.get(Hennepin);
+    verify(applicationRepository, times(1)).updateStatus(application.getId(), CCAP,
+        routingDestination, SENDING);
+    verify(applicationRepository, times(1)).updateStatus(application.getId(), CAF,
+        routingDestination, SENDING);
     verify(applicationRepository, timeout(2000).atLeastOnce()).updateStatus(application.getId(),
         CCAP, DELIVERY_FAILED);
+    verify(applicationRepository, timeout(2000).atLeastOnce()).updateStatus(application.getId(),
+        CCAP, routingDestination, DELIVERY_FAILED);
   }
 
   @Test
@@ -488,7 +501,10 @@ class MnitDocumentConsumerTest {
 
     documentConsumer.processUploadedDocuments(application);
 
+    CountyRoutingDestination routingDestination = countyMap.get(Olmsted);
     verify(applicationRepository).updateStatus(application.getId(), UPLOADED_DOC, SENDING);
+    verify(applicationRepository).updateStatus(application.getId(), UPLOADED_DOC,
+        routingDestination, SENDING);
   }
 
   @Test

--- a/src/test/java/org/codeforamerica/shiba/output/MnitDocumentConsumerTest.java
+++ b/src/test/java/org/codeforamerica/shiba/output/MnitDocumentConsumerTest.java
@@ -16,7 +16,18 @@ import static org.codeforamerica.shiba.output.Recipient.CASEWORKER;
 import static org.codeforamerica.shiba.testutilities.TestUtils.getAbsoluteFilepath;
 import static org.codeforamerica.shiba.testutilities.TestUtils.resetApplicationData;
 import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.NONE;
 
 import de.redsix.pdfcompare.PdfComparator;
@@ -334,9 +345,6 @@ class MnitDocumentConsumerTest {
 
     documentConsumer.processCafAndCcap(application);
 
-    verify(applicationRepository).updateStatus(application.getId(), CAF, SENDING);
-    verify(applicationRepository).updateStatus(application.getId(), CCAP, SENDING);
-
     CountyRoutingDestination routingDestination = countyMap.get(Hennepin);
     verify(applicationRepository).updateStatus(application.getId(), CAF, routingDestination,
         SENDING);
@@ -360,16 +368,11 @@ class MnitDocumentConsumerTest {
 
     documentConsumer.processCafAndCcap(application);
 
-    verify(applicationRepository, times(1)).updateStatus(application.getId(), CCAP, SENDING);
-    verify(applicationRepository, times(1)).updateStatus(application.getId(), CAF, SENDING);
-
     CountyRoutingDestination routingDestination = countyMap.get(Hennepin);
     verify(applicationRepository, times(1)).updateStatus(application.getId(), CCAP,
         routingDestination, SENDING);
     verify(applicationRepository, times(1)).updateStatus(application.getId(), CAF,
         routingDestination, SENDING);
-    verify(applicationRepository, timeout(2000).atLeastOnce()).updateStatus(application.getId(),
-        CCAP, DELIVERY_FAILED);
     verify(applicationRepository, timeout(2000).atLeastOnce()).updateStatus(application.getId(),
         CCAP, routingDestination, DELIVERY_FAILED);
   }
@@ -502,7 +505,6 @@ class MnitDocumentConsumerTest {
     documentConsumer.processUploadedDocuments(application);
 
     CountyRoutingDestination routingDestination = countyMap.get(Olmsted);
-    verify(applicationRepository).updateStatus(application.getId(), UPLOADED_DOC, SENDING);
     verify(applicationRepository).updateStatus(application.getId(), UPLOADED_DOC,
         routingDestination, SENDING);
   }

--- a/src/test/java/org/codeforamerica/shiba/pages/PageControllerTest.java
+++ b/src/test/java/org/codeforamerica/shiba/pages/PageControllerTest.java
@@ -469,7 +469,6 @@ class PageControllerTest {
                 .param("type", "jpg"))
         .andExpect(status().is(200));
 
-    verify(applicationRepository).updateStatus(application.getId(), UPLOADED_DOC, IN_PROGRESS);
     verify(applicationRepository).updateStatus(application.getId(), UPLOADED_DOC,
         routingDestinations, IN_PROGRESS);
   }

--- a/src/test/java/org/codeforamerica/shiba/pages/emails/MailGunEmailClientTest.java
+++ b/src/test/java/org/codeforamerica/shiba/pages/emails/MailGunEmailClientTest.java
@@ -222,7 +222,6 @@ class MailGunEmailClientTest {
     when(emailContentCreator.createHennepinDocUploadsHTML(anyMap())).thenReturn(emailContent);
 
     mailGunEmailClient.sendHennepinDocUploadsEmails(application, List.of(testFile, testFile));
-    verify(applicationRepository).updateStatus("someId", UPLOADED_DOC, Status.DELIVERED);
     verify(applicationRepository).updateStatus("someId", UPLOADED_DOC, "Hennepin",
         Status.DELIVERED);
 
@@ -279,7 +278,6 @@ class MailGunEmailClientTest {
     when(emailContentCreator.createHennepinDocUploadsHTML(anyMap())).thenReturn(emailContent);
 
     mailGunEmailClient.sendHennepinDocUploadsEmails(application, List.of(testFile, testFile));
-    verify(applicationRepository).updateStatus("someId", UPLOADED_DOC, Status.DELIVERED);
     verify(applicationRepository).updateStatus("someId", UPLOADED_DOC, "Hennepin",
         Status.DELIVERED);
 
@@ -339,7 +337,6 @@ class MailGunEmailClientTest {
     when(emailContentCreator.createHennepinDocUploadsHTML(anyMap())).thenReturn(emailContent);
 
     mailGunEmailClient.sendHennepinDocUploadsEmails(application, List.of(testFile, testFile));
-    verify(applicationRepository).updateStatus("someId", UPLOADED_DOC, Status.DELIVERED);
 
     wireMockServer.verify(1, postToMailgun()
         .withBasicAuth(credentials)

--- a/src/test/java/org/codeforamerica/shiba/pages/emails/MailGunEmailClientTest.java
+++ b/src/test/java/org/codeforamerica/shiba/pages/emails/MailGunEmailClientTest.java
@@ -223,6 +223,8 @@ class MailGunEmailClientTest {
 
     mailGunEmailClient.sendHennepinDocUploadsEmails(application, List.of(testFile, testFile));
     verify(applicationRepository).updateStatus("someId", UPLOADED_DOC, Status.DELIVERED);
+    verify(applicationRepository).updateStatus("someId", UPLOADED_DOC, "Hennepin",
+        Status.DELIVERED);
 
     wireMockServer.verify(1, postToMailgun()
         .withBasicAuth(new BasicCredentials("api", mailGunApiKey))
@@ -278,6 +280,8 @@ class MailGunEmailClientTest {
 
     mailGunEmailClient.sendHennepinDocUploadsEmails(application, List.of(testFile, testFile));
     verify(applicationRepository).updateStatus("someId", UPLOADED_DOC, Status.DELIVERED);
+    verify(applicationRepository).updateStatus("someId", UPLOADED_DOC, "Hennepin",
+        Status.DELIVERED);
 
     wireMockServer.verify(2, postToMailgun()
         .withBasicAuth(new BasicCredentials("api", mailGunApiKey))

--- a/src/test/resources/test-schema-init.sql
+++ b/src/test/resources/test-schema-init.sql
@@ -22,8 +22,21 @@ CREATE TABLE IF NOT EXISTS applications
     doc_upload_email_status         varchar
 );
 
+CREATE TABLE IF NOT EXISTS  application_status
+(
+    application_id      VARCHAR,
+    document_type       VARCHAR,
+    routing_destination VARCHAR,
+    status              VARCHAR,
+    created_at          TIMESTAMP,
+    updated_at          TIMESTAMP
+);
+
 CREATE INDEX IF NOT EXISTS idx_application_id
     ON applications (id);
+
+CREATE INDEX IF NOT EXISTS application_status_index
+  ON application_status (application_id, document_type, routing_destination);
 
 CREATE TABLE IF NOT EXISTS spring_session
 (


### PR DESCRIPTION
- Doesn't remove "in_progress" entries if applicant changes program selection
- Starts saving statuses when both document type and routing destination are present (after choosePrograms page)