### PR TITLE
Run ESB resubmissions once per node

### DIFF
--- a/src/main/java/org/codeforamerica/shiba/ResubmissionService.java
+++ b/src/main/java/org/codeforamerica/shiba/ResubmissionService.java
@@ -62,7 +62,7 @@ public class ResubmissionService {
       fixedDelayString = "${failed-resubmission.interval.milliseconds}",
       initialDelayString = "${failed-resubmission.initialDelay.milliseconds:0}"
   )
-  @SchedulerLock(name = "emailResubmissionTask", lockAtMostFor = "30m", lockAtLeastFor = "15m")
+  @SchedulerLock(name = "emailResubmissionTask", lockAtMostFor = "${failed-resubmission.lockAtMostFor}", lockAtLeastFor = "${failed-resubmission.lockAtLeastFor}")
   public void resubmitFailedApplications() {
     log.info("Checking for applications that failed to send");
     List<DocumentStatus> applicationsToResubmit = documentStatusRepository.getDocumentStatusToResubmit();
@@ -78,7 +78,7 @@ public class ResubmissionService {
       Document document = applicationStatus.getDocumentType();
       String routingDestinationName = applicationStatus.getRoutingDestinationName();
       log.info("Resubmitting " + document.name() + "(s) to " + routingDestinationName
-               + " for application id " + id);
+          + " for application id " + id);
       try {
         Application application = applicationRepository.find(id);
         RoutingDestination routingDestination = routingDecisionService.getRoutingDestinationByName(
@@ -103,10 +103,10 @@ public class ResubmissionService {
   }
 
   @Scheduled(
-      fixedDelayString = "${in-progress-resubmission.interval.milliseconds}", 
+      fixedDelayString = "${in-progress-resubmission.interval.milliseconds}",
       initialDelayString = "${in-progress-resubmission.initialDelay.milliseconds:0}"
   )
-  @SchedulerLock(name = "esbResubmissionTask", lockAtMostFor = "30m", lockAtLeastFor = "15m")
+  @SchedulerLock(name = "esbResubmissionTask", lockAtMostFor = "${in-progress-resubmission.lockAtMostFor}", lockAtLeastFor = "${in-progress-resubmission.lockAtLeastFor}")
   public void resubmitInProgressAndSendingApplicationsViaEsb() {
     log.info("Checking for applications that are stuck in progress");
 
@@ -121,23 +121,27 @@ public class ResubmissionService {
       log.info("Retriggering submission for application with id " + id);
 
       List<Document> inProgressDocs = application.getDocumentStatuses().stream()
-          .filter(documentStatus -> documentStatus.getStatus().equals(IN_PROGRESS) || documentStatus.getStatus().equals(SENDING) &&
-              List.of(CAF, CCAP, CERTAIN_POPS, UPLOADED_DOC).contains(documentStatus.getDocumentType())).map(
-                  DocumentStatus::getDocumentType
+          .filter(documentStatus -> documentStatus.getStatus().equals(IN_PROGRESS)
+              || documentStatus.getStatus().equals(SENDING) &&
+              List.of(CAF, CCAP, CERTAIN_POPS, UPLOADED_DOC)
+                  .contains(documentStatus.getDocumentType())).map(
+              DocumentStatus::getDocumentType
           ).collect(Collectors.toList());
 
       documentStatusRepository.delete(id, inProgressDocs);
 
-      boolean shouldRefireAppSubmittedEvent = inProgressDocs.stream().anyMatch(document -> List.of(CAF, CCAP, CERTAIN_POPS).contains(document));
-      if (shouldRefireAppSubmittedEvent){
+      boolean shouldRefireAppSubmittedEvent = inProgressDocs.stream()
+          .anyMatch(document -> List.of(CAF, CCAP, CERTAIN_POPS).contains(document));
+      if (shouldRefireAppSubmittedEvent) {
         log.info("Retriggering ApplicationSubmittedEvent for application with id " + id);
         pageEventPublisher.publish(new ApplicationSubmittedEvent("resubmission", id,
             application.getFlow(),
             application.getApplicationData().getLocale()));
       }
 
-      boolean shouldRefireUploadedDocSubmittedEvent = inProgressDocs.stream().anyMatch(document -> Objects.equals(
-          UPLOADED_DOC, document));
+      boolean shouldRefireUploadedDocSubmittedEvent = inProgressDocs.stream()
+          .anyMatch(document -> Objects.equals(
+              UPLOADED_DOC, document));
       if (shouldRefireUploadedDocSubmittedEvent) {
         log.info("Retriggering UploadedDocumentsSubmittedEvent for application with id " + id);
         pageEventPublisher.publish(

--- a/src/main/java/org/codeforamerica/shiba/ResubmissionService.java
+++ b/src/main/java/org/codeforamerica/shiba/ResubmissionService.java
@@ -59,10 +59,10 @@ public class ResubmissionService {
   }
 
   @Scheduled(
-      fixedDelayString = "${failed-resubmission.interval.milliseconds}", // how often to run (every 3 hours)
+      fixedDelayString = "${failed-resubmission.interval.milliseconds}",
       initialDelayString = "${failed-resubmission.initialDelay.milliseconds:0}"
   )
-  @SchedulerLock(name = "resubmissionTask", lockAtMostFor = "30m")
+  @SchedulerLock(name = "emailResubmissionTask", lockAtMostFor = "30m", lockAtLeastFor = "15m")
   public void resubmitFailedApplications() {
     log.info("Checking for applications that failed to send");
     List<DocumentStatus> applicationsToResubmit = documentStatusRepository.getDocumentStatusToResubmit();
@@ -103,10 +103,10 @@ public class ResubmissionService {
   }
 
   @Scheduled(
-      fixedDelayString = "${in-progress-resubmission.interval.milliseconds}", // how often to run (currently every 10 minutes)
+      fixedDelayString = "${in-progress-resubmission.interval.milliseconds}", 
       initialDelayString = "${in-progress-resubmission.initialDelay.milliseconds:0}"
   )
-  @SchedulerLock(name = "resubmissionTask", lockAtMostFor = "30m")
+  @SchedulerLock(name = "esbResubmissionTask", lockAtMostFor = "30m", lockAtLeastFor = "15m")
   public void resubmitInProgressAndSendingApplicationsViaEsb() {
     log.info("Checking for applications that are stuck in progress");
 

--- a/src/main/java/org/codeforamerica/shiba/application/ApplicationRepository.java
+++ b/src/main/java/org/codeforamerica/shiba/application/ApplicationRepository.java
@@ -99,14 +99,14 @@ public class ApplicationRepository {
   }
 
   public List<Application> findApplicationsStuckInProgressAndSending() {
-    Timestamp sixteenHoursAgo = Timestamp.from(Instant.now().minus(Duration.ofHours(16)));
+    Timestamp eightHoursAgo = Timestamp.from(Instant.now().minus(Duration.ofHours(8)));
     List<Application> applicationsStuckInProgress = jdbcTemplate.query(
         "SELECT * FROM applications where completed_at IS NOT NULL AND completed_at BETWEEN '2021-12-06' AND ? AND id IN ("
         + "    SELECT application_id FROM application_status WHERE status= 'in_progress' OR status ='sending'"
         + "          AND (document_type='CAF' OR document_type='CCAP' OR document_type='UPLOADED_DOC' OR document_type='CERTAIN_POPS')"
-        + "    ) ORDER BY completed_at LIMIT 5",
+        + "    ) ORDER BY completed_at LIMIT 50",
         applicationRowMapper(),
-        sixteenHoursAgo);
+        eightHoursAgo);
 
     // add document statuses to apps
     for (Application app : applicationsStuckInProgress) {

--- a/src/main/java/org/codeforamerica/shiba/output/DocumentUploadEmailService.java
+++ b/src/main/java/org/codeforamerica/shiba/output/DocumentUploadEmailService.java
@@ -61,7 +61,7 @@ public class DocumentUploadEmailService {
    * - opted into email communications
    */
   @Scheduled(cron = "${documentUploadEmails.cronExpression}")
-  @SchedulerLock(name = "documentUploadEmails", lockAtMostFor = "30m")
+  @SchedulerLock(name = "documentUploadEmails", lockAtMostFor = "30m", lockAtLeastFor = "15m")
   public void sendDocumentUploadEmails() {
     log.info("Checking for applications that need document upload emails");
     List<Application> applications = getApplicationsThatNeedDocumentUploadEmails();

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -101,7 +101,7 @@ failed-resubmission:
 
 in-progress-resubmission:
   interval:
-    milliseconds: 600000 # Run the ResubmissionService every 10 minutes (10m * 60s * 1000ms)
+    milliseconds: 3600000 # Run the ResubmissionService every hour (6 * 10m * 60s * 1000ms)
   initialDelay:
     milliseconds: 0 # Run the process as soon the app first starts up
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -98,11 +98,15 @@ failed-resubmission:
     milliseconds: 10800000 # Run the ResubmissionService every 3 hours
   initialDelay:
     milliseconds: 0 # Run the process as soon the app first starts up
+  lockAtLeastFor: 15m
+  lockAtMostFor: 30m
 
 in-progress-resubmission:
   interval:
     milliseconds: 3600000 # Run the ResubmissionService every hour (6 * 10m * 60s * 1000ms)
   initialDelay:
     milliseconds: 0 # Run the process as soon the app first starts up
+  lockAtLeastFor: 15m
+  lockAtMostFor: 30m
 
 demo-banner: false

--- a/src/test/java/org/codeforamerica/shiba/AppsStuckInProgressResubmissionTest.java
+++ b/src/test/java/org/codeforamerica/shiba/AppsStuckInProgressResubmissionTest.java
@@ -44,10 +44,8 @@ class AppsStuckInProgressResubmissionTest {
 
   @Test
   void itTriggersAnEventFor50AppsStuckInProgress() {
-    
-    int appCount = 50;
     // Only the first 50 of these should be resubmitted.
-    for (int i = 0; i < appCount+1; i++) {
+    for (int i = 0; i < 51; i++) {
       makeApplicationThatShouldBeResubmitted(i, Status.IN_PROGRESS);
     }
 
@@ -55,7 +53,7 @@ class AppsStuckInProgressResubmissionTest {
     resubmissionService.resubmitInProgressAndSendingApplicationsViaEsb();
 
     // make sure that the first 50 applications had an applicationSubmittedEvent triggered
-    for (int i = 0; i < appCount; i++) {
+    for (int i = 0; i < 50; i++) {
       verify(pageEventPublisher).publish(
           new ApplicationSubmittedEvent("resubmission", String.valueOf(i), FlowType.FULL,
               LocaleContextHolder.getLocale()));
@@ -66,18 +64,17 @@ class AppsStuckInProgressResubmissionTest {
 
     // Other applications should not have the event triggered
     verify(pageEventPublisher, never()).publish(
-        new ApplicationSubmittedEvent("resubmission", String.valueOf(appCount), FlowType.FULL,
+        new ApplicationSubmittedEvent("resubmission", String.valueOf(50), FlowType.FULL,
             LocaleContextHolder.getLocale()));
     verify(pageEventPublisher, never()).publish(
-        new UploadedDocumentsSubmittedEvent("resubmission", String.valueOf(appCount),
+        new UploadedDocumentsSubmittedEvent("resubmission", String.valueOf(50),
             LocaleContextHolder.getLocale()));
   }
 
   @Test
   void itTriggersAnEventFor50AppsStuckSending() {
-    int appCount = 50;
     // Only the first 50 of these should be resubmitted.
-    for (int i = 0; i < appCount+1; i++) {
+    for (int i = 60; i < 111; i++) {
       makeApplicationThatShouldBeResubmitted(i, Status.SENDING);
     }
 
@@ -85,7 +82,7 @@ class AppsStuckInProgressResubmissionTest {
     resubmissionService.resubmitInProgressAndSendingApplicationsViaEsb();
 
     // make sure that the first 50 applications had an applicationSubmittedEvent triggered
-    for (int i = 0; i < appCount; i++) {
+    for (int i = 60; i < 110; i++) {
       verify(pageEventPublisher).publish(
           new ApplicationSubmittedEvent("resubmission", String.valueOf(i), FlowType.FULL,
               LocaleContextHolder.getLocale()));

--- a/src/test/java/org/codeforamerica/shiba/AppsStuckInProgressResubmissionTest.java
+++ b/src/test/java/org/codeforamerica/shiba/AppsStuckInProgressResubmissionTest.java
@@ -142,7 +142,7 @@ class AppsStuckInProgressResubmissionTest {
         .build());
 
     Application inProgressApplicationThatShouldBeCompleted = Application.builder()
-        .completedAt(ZonedDateTime.now().minusHours(20)) // important that this is completed!!!
+        .completedAt(ZonedDateTime.now().minusHours(10)) // important that this is completed!!!
         .county(County.Anoka)
         .id(applicationId)
         .applicationData(applicationData)
@@ -208,7 +208,7 @@ class AppsStuckInProgressResubmissionTest {
         .build());
     String applicationId = "7";
     Application inProgressApplicationThatShouldBeCompleted = Application.builder()
-        .completedAt(ZonedDateTime.now().minusHours(24)) // important that this is completed!!!
+        .completedAt(ZonedDateTime.now().minusHours(12)) // important that this is completed!!!
         .county(County.Anoka)
         .id(applicationId)
         .applicationData(applicationData)

--- a/src/test/java/org/codeforamerica/shiba/AppsStuckInProgressResubmissionTest.java
+++ b/src/test/java/org/codeforamerica/shiba/AppsStuckInProgressResubmissionTest.java
@@ -43,17 +43,19 @@ class AppsStuckInProgressResubmissionTest {
   private PageEventPublisher pageEventPublisher;
 
   @Test
-  void itTriggersAnEventFor5AppsStuckInProgress() {
-    // Only the first 5 of these should be resubmitted.
-    for (int i = 0; i < 6; i++) {
+  void itTriggersAnEventFor50AppsStuckInProgress() {
+    
+    int appCount = 50;
+    // Only the first 50 of these should be resubmitted.
+    for (int i = 0; i < appCount+1; i++) {
       makeApplicationThatShouldBeResubmitted(i, Status.IN_PROGRESS);
     }
 
     // actually try to resubmit it
     resubmissionService.resubmitInProgressAndSendingApplicationsViaEsb();
 
-    // make sure that the first 5 applications had an applicationSubmittedEvent triggered
-    for (int i = 0; i < 5; i++) {
+    // make sure that the first 50 applications had an applicationSubmittedEvent triggered
+    for (int i = 0; i < appCount; i++) {
       verify(pageEventPublisher).publish(
           new ApplicationSubmittedEvent("resubmission", String.valueOf(i), FlowType.FULL,
               LocaleContextHolder.getLocale()));
@@ -64,25 +66,26 @@ class AppsStuckInProgressResubmissionTest {
 
     // Other applications should not have the event triggered
     verify(pageEventPublisher, never()).publish(
-        new ApplicationSubmittedEvent("resubmission", String.valueOf(5), FlowType.FULL,
+        new ApplicationSubmittedEvent("resubmission", String.valueOf(appCount), FlowType.FULL,
             LocaleContextHolder.getLocale()));
     verify(pageEventPublisher, never()).publish(
-        new UploadedDocumentsSubmittedEvent("resubmission", String.valueOf(5),
+        new UploadedDocumentsSubmittedEvent("resubmission", String.valueOf(appCount),
             LocaleContextHolder.getLocale()));
   }
 
   @Test
-  void itTriggersAnEventFor5AppsStuckSending() {
-    // Only the first 5 of these should be resubmitted.
-    for (int i = 10; i < 16; i++) {
+  void itTriggersAnEventFor50AppsStuckSending() {
+    int appCount = 50;
+    // Only the first 50 of these should be resubmitted.
+    for (int i = 0; i < appCount+1; i++) {
       makeApplicationThatShouldBeResubmitted(i, Status.SENDING);
     }
 
     // actually try to resubmit it
     resubmissionService.resubmitInProgressAndSendingApplicationsViaEsb();
 
-    // make sure that the first 5 applications had an applicationSubmittedEvent triggered
-    for (int i = 10; i < 15; i++) {
+    // make sure that the first 50 applications had an applicationSubmittedEvent triggered
+    for (int i = 0; i < appCount; i++) {
       verify(pageEventPublisher).publish(
           new ApplicationSubmittedEvent("resubmission", String.valueOf(i), FlowType.FULL,
               LocaleContextHolder.getLocale()));
@@ -91,6 +94,7 @@ class AppsStuckInProgressResubmissionTest {
               LocaleContextHolder.getLocale()));
     }
   }
+  
   @Test
   void itDoesNotTriggerAnEventForAppsThatShouldNotBeResubmitted() {
     String applicationIdToResubmit = makeApplicationThatShouldBeResubmitted(1, Status.IN_PROGRESS);

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -47,7 +47,11 @@ documentUploadEmails:
 failed-resubmission:
   initialDelay:
     milliseconds: 2629800000 # Wait a month after the app starts to run the method, i.e don't run it at all
+  lockAtMostFor: "0m"
+  lockAtLeastFor: "0m"
 
 in-progress-resubmission:
   initialDelay:
     milliseconds: 2629800000 # Wait a month after the app starts to run the method, i.e don't run it at all
+  lockAtMostFor: "0m"
+  lockAtLeastFor: "0m"


### PR DESCRIPTION
- Resubmission over now only occurs on apps completed half an hour after the last retry: 8 hours after submission.
- Lock esbResubmissionTask to run once per node every hour on no more than 50 applications

[#181451258]