### PR TITLE
Update resubmission logic to set later docs with no uploaded document…

### DIFF
--- a/src/main/java/org/codeforamerica/shiba/application/Application.java
+++ b/src/main/java/org/codeforamerica/shiba/application/Application.java
@@ -8,6 +8,7 @@ import java.util.Optional;
 import lombok.Builder;
 import lombok.Data;
 import org.codeforamerica.shiba.County;
+import org.codeforamerica.shiba.output.Document;
 import org.codeforamerica.shiba.pages.Feedback;
 import org.codeforamerica.shiba.pages.Sentiment;
 import org.codeforamerica.shiba.pages.data.ApplicationData;
@@ -51,5 +52,18 @@ public class Application {
   public void setCompletedAtTime(Clock clock) {
     completedAt = ZonedDateTime.now(clock);
     setTimeToComplete(Duration.between(applicationData.getStartTime(), completedAt));
+  }
+
+  public Status getApplicationStatus(Document document, String routingDestination) {
+    if (documentStatuses != null) {
+      return documentStatuses.stream()
+          .filter(appStatus -> appStatus.getDocumentType() == document
+              && (appStatus.getRoutingDestinationName() == null
+              || appStatus.getRoutingDestinationName()
+              .equals(routingDestination)))
+          .findFirst()
+          .map(DocumentStatus::getStatus).orElse(null);
+    }
+    return null;
   }
 }

--- a/src/main/java/org/codeforamerica/shiba/pages/PageController.java
+++ b/src/main/java/org/codeforamerica/shiba/pages/PageController.java
@@ -666,7 +666,8 @@ public class PageController {
     LocaleSpecificMessageSource lms = new LocaleSpecificMessageSource(locale, messageSource);
     try {
       Application application = applicationRepository.find(applicationData.getId());
-      if (application.getDocumentStatuses().stream()
+      if (application.getDocumentStatuses() == null ||
+          application.getDocumentStatuses().stream()
           .filter(documentStatus -> documentStatus.getDocumentType() == UPLOADED_DOC)
           .noneMatch(documentStatus -> List.of(SENDING, DELIVERED).contains(documentStatus.getStatus()))) {
         // Don't overwrite a "completed" status

--- a/src/main/java/org/codeforamerica/shiba/pages/PageController.java
+++ b/src/main/java/org/codeforamerica/shiba/pages/PageController.java
@@ -3,11 +3,13 @@ package org.codeforamerica.shiba.pages;
 import static java.util.Optional.ofNullable;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.codeforamerica.shiba.application.FlowType.LATER_DOCS;
+import static org.codeforamerica.shiba.application.Status.DELIVERED;
 import static org.codeforamerica.shiba.application.Status.IN_PROGRESS;
 import static org.codeforamerica.shiba.application.Status.SENDING;
 import static org.codeforamerica.shiba.application.parsers.ApplicationDataParser.Field.HOME_ZIPCODE;
 import static org.codeforamerica.shiba.application.parsers.ApplicationDataParser.getFirstValue;
 import static org.codeforamerica.shiba.output.Document.UPLOADED_DOC;
+
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -17,7 +19,15 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Clock;
 import java.time.ZoneId;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
 import javax.imageio.ImageIO;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
@@ -41,10 +51,24 @@ import org.codeforamerica.shiba.internationalization.LocaleSpecificMessageSource
 import org.codeforamerica.shiba.mnit.RoutingDestination;
 import org.codeforamerica.shiba.output.caf.CcapExpeditedEligibilityDecider;
 import org.codeforamerica.shiba.output.caf.SnapExpeditedEligibilityDecider;
-import org.codeforamerica.shiba.pages.config.*;
-import org.codeforamerica.shiba.pages.data.*;
+import org.codeforamerica.shiba.pages.config.ApplicationConfiguration;
+import org.codeforamerica.shiba.pages.config.FeatureFlagConfiguration;
+import org.codeforamerica.shiba.pages.config.LandmarkPagesConfiguration;
+import org.codeforamerica.shiba.pages.config.NextPage;
+import org.codeforamerica.shiba.pages.config.PageConfiguration;
+import org.codeforamerica.shiba.pages.config.PageTemplate;
+import org.codeforamerica.shiba.pages.config.PageWorkflowConfiguration;
+import org.codeforamerica.shiba.pages.data.ApplicationData;
+import org.codeforamerica.shiba.pages.data.DatasourcePages;
+import org.codeforamerica.shiba.pages.data.PageData;
+import org.codeforamerica.shiba.pages.data.PagesData;
+import org.codeforamerica.shiba.pages.data.UploadedDocument;
 import org.codeforamerica.shiba.pages.enrichment.ApplicationEnrichment;
-import org.codeforamerica.shiba.pages.events.*;
+import org.codeforamerica.shiba.pages.events.ApplicationSubmittedEvent;
+import org.codeforamerica.shiba.pages.events.PageEventPublisher;
+import org.codeforamerica.shiba.pages.events.SubworkflowCompletedEvent;
+import org.codeforamerica.shiba.pages.events.SubworkflowIterationDeletedEvent;
+import org.codeforamerica.shiba.pages.events.UploadedDocumentsSubmittedEvent;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.context.MessageSource;
 import org.springframework.context.i18n.LocaleContextHolder;
@@ -53,7 +77,12 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.mobile.device.Device;
 import org.springframework.stereotype.Controller;
 import org.springframework.util.MultiValueMap;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
@@ -587,7 +616,7 @@ public class PageController {
       return new ModelAndView("redirect:/pages/" + submitPage);
     }
   }
-  
+
   private void recordDeviceType(Device device, Application application) {
       String deviceType = "unknown";
       String platform = "unknown";
@@ -636,7 +665,14 @@ public class PageController {
       Locale locale) throws IOException, InterruptedException {
     LocaleSpecificMessageSource lms = new LocaleSpecificMessageSource(locale, messageSource);
     try {
-      documentStatusRepository.createOrUpdateAllForDocumentType(applicationData, IN_PROGRESS, UPLOADED_DOC);
+      Application application = applicationRepository.find(applicationData.getId());
+      if (application.getDocumentStatuses().stream()
+          .filter(documentStatus -> documentStatus.getDocumentType() == UPLOADED_DOC)
+          .noneMatch(documentStatus -> List.of(SENDING, DELIVERED).contains(documentStatus.getStatus()))) {
+        // Don't overwrite a "completed" status
+        documentStatusRepository.createOrUpdateAllForDocumentType(applicationData, IN_PROGRESS,
+            UPLOADED_DOC);
+      }
 
       if (applicationData.getUploadedDocs().size() <= MAX_FILES_UPLOADED &&
           file.getSize() <= uploadDocumentConfiguration.getMaxFilesizeInBytes()) {
@@ -655,10 +691,10 @@ public class PageController {
                 HttpStatus.UNPROCESSABLE_ENTITY);
           }
         }
-        
+
         var filePath = applicationData.getId() + "/" + UUID.randomUUID();
         var thumbnailFilePath = applicationData.getId() + "/" + UUID.randomUUID();
-        
+
         if(file.getContentType()!=null && file.getContentType().contains("image")) {
           Path paths = Files.createTempDirectory("");
           File thumbFile = new File(paths.toFile(),file.getOriginalFilename());
@@ -668,7 +704,7 @@ public class PageController {
           ByteArrayOutputStream os = new ByteArrayOutputStream();
           BufferedImage outputImage = Thumbnails.of(thumbFile).size(300, 300).asBufferedImage();
           ImageIO.write(outputImage, "png", os);
-          dataURL = "data:image/png;base64,"+Base64.getEncoder().encodeToString(os.toByteArray());
+          dataURL = "data:image/png;base64," + Base64.getEncoder().encodeToString(os.toByteArray());
           outputImage.flush();
           thumbFile.delete();
           Files.delete(paths);
@@ -679,7 +715,7 @@ public class PageController {
       }
 
       return new ResponseEntity<>(HttpStatus.OK);
-    } 
+    }
     catch (Exception e) {
       log.error("Error Occurred while uploading File " + e.getLocalizedMessage());
       // If there's any uncaught exception, return a default error message

--- a/src/test/java/org/codeforamerica/shiba/AppsStuckInProgressResubmissionTest.java
+++ b/src/test/java/org/codeforamerica/shiba/AppsStuckInProgressResubmissionTest.java
@@ -1,20 +1,29 @@
 package org.codeforamerica.shiba;
 
+import static org.codeforamerica.shiba.County.Anoka;
 import static org.codeforamerica.shiba.Program.CASH;
 import static org.codeforamerica.shiba.Program.SNAP;
+import static org.codeforamerica.shiba.application.Status.DELIVERED;
+import static org.codeforamerica.shiba.application.Status.SENDING;
+import static org.codeforamerica.shiba.output.Document.UPLOADED_DOC;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
-import org.codeforamerica.shiba.application.*;
+import org.codeforamerica.shiba.application.Application;
+import org.codeforamerica.shiba.application.ApplicationRepository;
+import org.codeforamerica.shiba.application.DocumentStatusRepository;
+import org.codeforamerica.shiba.application.FlowType;
+import org.codeforamerica.shiba.application.Status;
 import org.codeforamerica.shiba.output.Document;
 import org.codeforamerica.shiba.pages.data.ApplicationData;
 import org.codeforamerica.shiba.pages.events.ApplicationSubmittedEvent;
 import org.codeforamerica.shiba.pages.events.PageEventPublisher;
 import org.codeforamerica.shiba.pages.events.UploadedDocumentsSubmittedEvent;
 import org.codeforamerica.shiba.testutilities.PagesDataBuilder;
+import org.codeforamerica.shiba.testutilities.TestApplicationDataBuilder;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -75,7 +84,7 @@ class AppsStuckInProgressResubmissionTest {
   void itTriggersAnEventFor50AppsStuckSending() {
     // Only the first 50 of these should be resubmitted.
     for (int i = 60; i < 111; i++) {
-      makeApplicationThatShouldBeResubmitted(i, Status.SENDING);
+      makeApplicationThatShouldBeResubmitted(i, SENDING);
     }
 
     // actually try to resubmit it
@@ -129,7 +138,7 @@ class AppsStuckInProgressResubmissionTest {
   private String makeApplicationThatShouldBeResubmitted(int id, Status status) {
     String applicationId = String.valueOf(id);
 
-    ApplicationData applicationData = new ApplicationData();
+    ApplicationData applicationData = new TestApplicationDataBuilder().withUploadedDocs();
     applicationData.setPagesData(new PagesDataBuilder()
         .withPageData("contactInfo", Map.of(
             "email", List.of("test@example.com"),
@@ -140,7 +149,7 @@ class AppsStuckInProgressResubmissionTest {
 
     Application inProgressApplicationThatShouldBeCompleted = Application.builder()
         .completedAt(ZonedDateTime.now().minusHours(10)) // important that this is completed!!!
-        .county(County.Anoka)
+        .county(Anoka)
         .id(applicationId)
         .applicationData(applicationData)
         .docUploadEmailStatus(null)
@@ -157,9 +166,9 @@ class AppsStuckInProgressResubmissionTest {
 
     documentStatusRepository.createOrUpdate(
         applicationId,
-        Document.UPLOADED_DOC,
+        UPLOADED_DOC,
         "Anoka",
-        status);
+        SENDING);
 
     return applicationId;
   }
@@ -177,7 +186,7 @@ class AppsStuckInProgressResubmissionTest {
     String applicationId = "6";
     Application inProgressApplicationThatShouldBeCompleted = Application.builder()
         .completedAt(ZonedDateTime.now().minusHours(1)) // important that this is completed!!!
-        .county(County.Anoka)
+        .county(Anoka)
         .id(applicationId)
         .applicationData(applicationData)
         .docUploadEmailStatus(null)
@@ -206,7 +215,7 @@ class AppsStuckInProgressResubmissionTest {
     String applicationId = "7";
     Application inProgressApplicationThatShouldBeCompleted = Application.builder()
         .completedAt(ZonedDateTime.now().minusHours(12)) // important that this is completed!!!
-        .county(County.Anoka)
+        .county(Anoka)
         .id(applicationId)
         .applicationData(applicationData)
         .docUploadEmailStatus(null)
@@ -218,7 +227,7 @@ class AppsStuckInProgressResubmissionTest {
         applicationId,
         Document.CAF,
         "Anoka",
-        Status.DELIVERED);
+        DELIVERED);
     return applicationId;
   }
 }

--- a/src/test/java/org/codeforamerica/shiba/pages/PageControllerTest.java
+++ b/src/test/java/org/codeforamerica/shiba/pages/PageControllerTest.java
@@ -492,7 +492,7 @@ class PageControllerTest {
         .id(applicationId)
         .applicationData(applicationData)
         .build();
-    when(applicationRepository.getNextId()).thenReturn(applicationId);
+    when(applicationRepository.find("someId")).thenReturn(application);
     when(applicationFactory.newApplication(applicationData)).thenReturn(application);
     List<RoutingDestination> routingDestinations =
         List.of(new TribalNationRoutingDestination("Mille Lacs Band of Ojibwe"));


### PR DESCRIPTION
…s to undeliverable

- Do not publish events for documents that are undeliverable
- Stop setting applications with uploaded docs back to in_progress from sending or delivered

Co-authored-by: Ben Calegari <bcalegari@codeforamerica.org>
Co-authored-by: Sree Prasad <sprasad@codeforamerica.org>