### PR TITLE
Overwriting default configurations for ThreadExecutor

### DIFF
--- a/src/main/java/org/codeforamerica/shiba/configurations/SpringAsyncConfiguration.java
+++ b/src/main/java/org/codeforamerica/shiba/configurations/SpringAsyncConfiguration.java
@@ -1,6 +1,7 @@
 package org.codeforamerica.shiba.configurations;
 
 import java.util.concurrent.Executor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.AsyncConfigurer;
 import org.springframework.scheduling.annotation.EnableAsync;
@@ -9,13 +10,15 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 @Configuration
 @EnableAsync
 public class SpringAsyncConfiguration implements AsyncConfigurer {
+  @Value("${asyncConfiguration.corePoolSize}") int corePoolSize;
+  @Value("${asyncConfiguration.queueCapacity}") int queueCapacity;
 
   @Override
   public Executor getAsyncExecutor() {
     ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
-    executor.setCorePoolSize(10);
+    executor.setCorePoolSize(corePoolSize);
     // keep the queue small to avoid excessive delay if there are ESB retries
-    executor.setQueueCapacity(2);
+    executor.setQueueCapacity(queueCapacity );
     executor.setWaitForTasksToCompleteOnShutdown(true); // avoid interruptionException
     executor.setThreadNamePrefix("AsyncExecutor-");
     executor.initialize();

--- a/src/main/java/org/codeforamerica/shiba/configurations/SpringAsyncConfiguration.java
+++ b/src/main/java/org/codeforamerica/shiba/configurations/SpringAsyncConfiguration.java
@@ -1,10 +1,24 @@
 package org.codeforamerica.shiba.configurations;
 
+import java.util.concurrent.Executor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
 import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 @Configuration
 @EnableAsync
-public class SpringAsyncConfiguration {
+public class SpringAsyncConfiguration implements AsyncConfigurer {
 
+  @Override
+  public Executor getAsyncExecutor() {
+    ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+    executor.setCorePoolSize(10);
+    // keep the queue small to avoid excessive delay if there are ESB retries
+    executor.setQueueCapacity(2);
+    executor.setWaitForTasksToCompleteOnShutdown(true); // avoid interruptionException
+    executor.setThreadNamePrefix("AsyncExecutor-");
+    executor.initialize();
+    return executor;
+  }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -95,6 +95,10 @@ logging:
 
 pagesConfig: pages-config.yaml
 
+asyncConfiguration:
+  corePoolSize: ${ASYNC_THREAD_POOL}
+  queueCapacity: ${ASYNC_QUEUE_CAPACITY}
+
 documentUploadEmails:
   cronExpression: "0 0 15 * * *" # send document upload emails at 15:00 UTC (10:00 CT) each day
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -96,8 +96,8 @@ logging:
 pagesConfig: pages-config.yaml
 
 asyncConfiguration:
-  corePoolSize: ${ASYNC_THREAD_POOL}
-  queueCapacity: ${ASYNC_QUEUE_CAPACITY}
+  corePoolSize: ${ASYNC_THREAD_POOL:10}
+  queueCapacity: ${ASYNC_QUEUE_CAPACITY:2}
 
 documentUploadEmails:
   cronExpression: "0 0 15 * * *" # send document upload emails at 15:00 UTC (10:00 CT) each day

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -56,7 +56,6 @@ in-progress-resubmission:
   lockAtMostFor: "0m"
   lockAtLeastFor: "0m"
 
-
 no-status-applications-resubmission:
   initialDelay:
     milliseconds: 2629800000 # Run the process as soon the app first starts up


### PR DESCRIPTION
# What
- start with 10 threads for ESB submissions (default is 1)
- lower queue capacity so that more threads will spin up to complete tasks (default queue capacity is integer.max)

# Why
By default we have 1 thread and a large queue for submitting applications via ESB. This is usually fine unless we're experiencing failures/retries on submission in which case, applications could be piling up in the queue waiting (up to 3 hours) for each submission to go through or fail. If we restart the application during this time, we'll lose all the queued events. 
By lowering the queue capacity, we can force more threads to spin up to send the applications.

