### PR TITLE
Adding check for docs that cant be sent

### DIFF
--- a/src/main/java/org/codeforamerica/shiba/application/Application.java
+++ b/src/main/java/org/codeforamerica/shiba/application/Application.java
@@ -3,6 +3,7 @@ package org.codeforamerica.shiba.application;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.ZonedDateTime;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import lombok.Builder;
@@ -52,6 +53,16 @@ public class Application {
   public void setCompletedAtTime(Clock clock) {
     completedAt = ZonedDateTime.now(clock);
     setTimeToComplete(Duration.between(applicationData.getStartTime(), completedAt));
+  }
+
+  public List<Status> getDocumentStatuses(Document document) {
+    if (documentStatuses != null) {
+      return documentStatuses.stream()
+          .filter(appStatus -> appStatus.getDocumentType() == document)
+          .map(DocumentStatus::getStatus)
+          .toList();
+    }
+    return Collections.emptyList();
   }
 
   public Status getApplicationStatus(Document document, String routingDestination) {

--- a/src/main/java/org/codeforamerica/shiba/output/caf/FilenameGenerator.java
+++ b/src/main/java/org/codeforamerica/shiba/output/caf/FilenameGenerator.java
@@ -57,6 +57,11 @@ public class FilenameGenerator {
   public String generateUploadedDocumentName(Application application, int index, String extension,
       RoutingDestination routingDestination) {
     int size = application.getApplicationData().getUploadedDocs().size();
+    return generateUploadedDocumentName(application, index, extension, routingDestination, size);
+  }
+
+  public String generateUploadedDocumentName(Application application, int index, String extension,
+      RoutingDestination routingDestination, int size) {
     index = index + 1;
     String dhsProviderId = routingDestination.getDhsProviderId();
     String prefix = getSharedApplicationPrefix(application, UPLOADED_DOC,

--- a/src/main/java/org/codeforamerica/shiba/output/pdf/PdfGenerator.java
+++ b/src/main/java/org/codeforamerica/shiba/output/pdf/PdfGenerator.java
@@ -117,7 +117,7 @@ public class PdfGenerator implements FileGenerator {
 				fileBytes = pdfWordConverter.convertWordDocToPDFwithStreams(inputStream);
 				extension = "pdf";
 			} catch (PdfOfficeException |IOException e) {
-                log.error("failed to convert document " + uploadedDocument.getFilename()
+                log.warn("failed to convert document " + uploadedDocument.getFilename()
                 + " to pdf. Maintaining original type. " + e.getMessage());
 			}
 
@@ -126,7 +126,7 @@ public class PdfGenerator implements FileGenerator {
 				fileBytes = convertImageToPdf(fileBytes, uploadedDocument.getFilename());
 				extension = "pdf";
 			} catch (Exception e) {
-				log.error("failed to convert document " + uploadedDocument.getFilename()
+				log.warn("failed to convert document " + uploadedDocument.getFilename()
 						+ " to pdf. Maintaining original type");
 			}
 		} else if (!extension.equals("pdf")) {

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -430,6 +430,7 @@ upload-documents.this-pdf-is-password-protected=This PDF is password protected. 
 upload-documents.this-pdf-is-in-an-old-format=This PDF is in an old format. Try converting it to an image or uploading a screenshot instead.
 upload-documents.there-was-an-issue-on-our-end=There was an issue processing this file on our end. Sorry about that! Please try another file or upload a screenshot instead.
 upload-documents.there-is-a-problem-with-the-image=This image cannot be uploaded to your application.  Please try another file or upload a screenshot instead.
+upload-documents.this-file-appears-to-be-empty=This file appears to be empty. Please try another file or upload a screenshot instead.
 
 upload-documents-delete-warning.title=Delete a file
 upload-documents-delete-warning.you-are-about-to-delete=You are about to delete your file called {0}.


### PR DESCRIPTION
- Add client-side check for empty files. Empty files are skipped from submission anyways - this will make it more clear to the client as well 
<img width="399" alt="Screen Shot 2022-03-16 at 1 06 16 PM" src="https://user-images.githubusercontent.com/72890349/158690980-356c952e-0704-4227-a8bb-8f3fc7566573.png">

- Update for resubmission. If all docs cant be sent (are skipped) for some reason, UPLOADED_DOC status will be set to "undeliverable"
- Update for generating filenames for uploaded_docs. Skipped documents are not included in total doc count
- Renamed thumbnail files to include "thumbnail" in the filename

