### PR TITLE
Fix post doc submit redirects

### DIFF
--- a/src/main/java/org/codeforamerica/shiba/pages/PageController.java
+++ b/src/main/java/org/codeforamerica/shiba/pages/PageController.java
@@ -818,10 +818,6 @@ public class PageController {
     LandmarkPagesConfiguration landmarkPagesConfiguration = applicationConfiguration
         .getLandmarkPages();
     String nextPage = landmarkPagesConfiguration.getNextStepsPage();
-    if (applicationData.getFlow() == LATER_DOCS) {
-      nextPage = landmarkPagesConfiguration.getLaterDocsTerminalPage();
-    }
-
     return new ModelAndView(String.format("redirect:/pages/%s", nextPage));
   }
 

--- a/src/main/java/org/codeforamerica/shiba/pages/PageController.java
+++ b/src/main/java/org/codeforamerica/shiba/pages/PageController.java
@@ -245,6 +245,17 @@ public class PageController {
           String.format("redirect:/pages/%s", landmarkPagesConfiguration.getTerminalPage()));
     }
 
+    if (shouldRedirectToNextStepsPage(pageName)) {
+      return new ModelAndView(
+          String.format("redirect:/pages/%s", landmarkPagesConfiguration.getNextStepsPage()));
+    }
+
+    if (shouldRedirectToLaterDocsTerminalPage(pageName)) {
+      return new ModelAndView(
+          String.format("redirect:/pages/%s",
+              landmarkPagesConfiguration.getLaterDocsTerminalPage()));
+    }
+
     if (shouldRedirectToLandingPage(pageName)) {
       return new ModelAndView(
           String.format("redirect:/pages/%s",
@@ -480,6 +491,27 @@ public class PageController {
            applicationData.isSubmitted();
   }
 
+  private boolean shouldRedirectToNextStepsPage(String pageName) {
+    LandmarkPagesConfiguration landmarkPagesConfiguration = applicationConfiguration
+        .getLandmarkPages();
+    // Documents have been submitted in non-later docs flow and applicant is attempting to navigate back to upload/submit docs pages
+    return !landmarkPagesConfiguration.isNextStepsPage(pageName) &&
+        (landmarkPagesConfiguration.isUploadDocumentsPage(pageName) ||
+            landmarkPagesConfiguration.isSubmitUploadedDocumentsPage(pageName))
+        && applicationData.getFlow() != LATER_DOCS
+        && hasSubmittedDocuments();
+  }
+
+  private boolean shouldRedirectToLaterDocsTerminalPage(String pageName) {
+    LandmarkPagesConfiguration landmarkPagesConfiguration = applicationConfiguration
+        .getLandmarkPages();
+    // Documents have been submitted in later docs flow and applicant is attempting to navigate back to a previous page in this flow
+    return !landmarkPagesConfiguration.isLaterDocsTerminalPage(pageName)
+        && landmarkPagesConfiguration.isPostSubmitPage(pageName)
+        && applicationData.getFlow() == LATER_DOCS
+        && hasSubmittedDocuments();
+  }
+
   @PostMapping("/groups/{groupName}/delete")
   RedirectView deleteGroup(@PathVariable String groupName, HttpSession httpSession) {
     applicationData.getSubworkflows().remove(groupName);
@@ -676,11 +708,8 @@ public class PageController {
       Locale locale) throws IOException, InterruptedException {
     LocaleSpecificMessageSource lms = new LocaleSpecificMessageSource(locale, messageSource);
     try {
-      Application application = applicationRepository.find(applicationData.getId());
-      // TODO if a document is "sending" or "delivered" should we redirect to the terminal page?
-      if (application.getDocumentStatuses(UPLOADED_DOC).stream()
-          .noneMatch(documentStatus -> List.of(SENDING, DELIVERED).contains(documentStatus))) {
-        // Don't overwrite a "completed" status
+      if (!hasSubmittedDocuments()) {
+        // Shouldn't run into this case, but we don't want to overwrite a "completed" status
         documentStatusRepository.createOrUpdateAllForDocumentType(applicationData, IN_PROGRESS,
             UPLOADED_DOC);
       }
@@ -724,6 +753,12 @@ public class PageController {
           lms.getMessage("upload-documents.there-was-an-issue-on-our-end"),
           HttpStatus.INTERNAL_SERVER_ERROR);
     }
+  }
+
+  private boolean hasSubmittedDocuments() {
+    Application application = applicationRepository.find(applicationData.getId());
+    return application.getDocumentStatuses(UPLOADED_DOC).stream()
+        .anyMatch(documentStatus -> List.of(SENDING, DELIVERED).contains(documentStatus));
   }
 
   @Nullable

--- a/src/main/java/org/codeforamerica/shiba/pages/config/LandmarkPagesConfiguration.java
+++ b/src/main/java/org/codeforamerica/shiba/pages/config/LandmarkPagesConfiguration.java
@@ -15,6 +15,7 @@ public class LandmarkPagesConfiguration {
   private String terminalPage;
   private String submitPage;
   private String uploadDocumentsPage;
+  private String submitUploadedDocumentsPage;
   private String laterDocsTerminalPage;
 
   public boolean isLandingPage(String pageName) {
@@ -43,6 +44,14 @@ public class LandmarkPagesConfiguration {
 
   public boolean isUploadDocumentsPage(String pageName) {
     return pageName.equals(uploadDocumentsPage);
+  }
+
+  public boolean isSubmitUploadedDocumentsPage(String pageName) {
+    return pageName.equals(submitUploadedDocumentsPage);
+  }
+
+  public boolean isNextStepsPage(String pageName) {
+    return pageName.equals(nextStepsPage);
   }
 
   public boolean isInProgressStatusPage(String pageName) {

--- a/src/main/resources/pages-config.yaml
+++ b/src/main/resources/pages-config.yaml
@@ -4322,4 +4322,5 @@ landmarkPages:
   terminalPage: success # the final page of the main flow ("Done! Your application has been submitted.")
   laterDocsTerminalPage: documentsSent # the final page of the laterdocs flow
   submitPage: signThisApplication
-  uploadDocumentsPage: uploadDocuments
+  uploadDocumentsPage: uploadDocuments # the page where applicants upload documents
+  submitUploadedDocumentsPage: documentSubmitConfirmation # the page where applicants confirm that the documents should be submitted

--- a/src/test/java/org/codeforamerica/shiba/journeys/FullFlowJourneyTest.java
+++ b/src/test/java/org/codeforamerica/shiba/journeys/FullFlowJourneyTest.java
@@ -35,6 +35,7 @@ public class FullFlowJourneyTest extends JourneyTest {
         LocalDateTime.of(2020, 1, 1, 10, 15, 30).atOffset(ZoneOffset.UTC).toInstant()
     );
     when(featureFlagConfiguration.get("certain-pops")).thenReturn(FeatureFlag.ON);
+    when(featureFlagConfiguration.get("submit-via-api")).thenReturn(FeatureFlag.ON);
 
     // Assert intercom button is present on landing page
     await().atMost(5, SECONDS).until(() -> !driver.findElementsById("intercom-frame").isEmpty());
@@ -416,7 +417,14 @@ public class FullFlowJourneyTest extends JourneyTest {
     // Finish uploading docs, view next steps, and download PDFs
     testPage.clickButton("Submit my documents");
     testPage.clickButton("Yes, submit and finish");
+
+    // Assert that applicant can't resubmit docs at this point
+    navigateTo("uploadDocuments");
+    assertThat(driver.getTitle()).isEqualTo("Your next steps");
+    navigateTo("documentSubmitConfirmation");
+    assertThat(driver.getTitle()).isEqualTo("Your next steps");
     testPage.clickContinue();
+
     SuccessPage successPage = new SuccessPage(driver);
     assertThat(successPage.findElementById("submission-date").getText()).contains(
         "Your application was submitted to Hennepin County (612-596-1300) and Mille Lacs Band of Ojibwe Tribal Nation Servicing Agency (320-532-7407) on January 1, 2020.");

--- a/src/test/java/org/codeforamerica/shiba/journeys/LaterDocsJourneyTest.java
+++ b/src/test/java/org/codeforamerica/shiba/journeys/LaterDocsJourneyTest.java
@@ -66,5 +66,12 @@ public class LaterDocsJourneyTest extends JourneyTest {
     testPage.clickButton("Yes, submit and finish");
     assertThat(driver.getTitle()).isEqualTo("Documents Sent");
     verify(pageEventPublisher).publish(any());
+
+    // Assert that applicant can't resubmit docs at this point
+    navigateTo("uploadDocuments");
+    assertThat(driver.getTitle()).isEqualTo("Documents Sent");
+
+    navigateTo("documentSubmitConfirmation");
+    assertThat(driver.getTitle()).isEqualTo("Documents Sent");
   }
 }

--- a/src/test/java/org/codeforamerica/shiba/pages/PageControllerTest.java
+++ b/src/test/java/org/codeforamerica/shiba/pages/PageControllerTest.java
@@ -580,6 +580,7 @@ class PageControllerTest {
         .build();
     when(applicationRepository.getNextId()).thenReturn(applicationId);
     when(applicationFactory.newApplication(applicationData)).thenReturn(application);
+    when(applicationRepository.find(applicationId)).thenReturn(application);
 
     when(documentRepository.get(any())).thenThrow(RuntimeException.class);
 


### PR DESCRIPTION
A client should not be able to resubmit the same documents they have already submitted, or to submit new documents after already submitting.
- For regular flow, a client who tries to navigate back to uploadDocuments or documentSubmitConfirmation pages (after submitting docs) will be sent to "Next Steps"
- For later docs flow, a client who tries to navigate back to any prior later-docs page (after submitting docs) will be sent to "Documents Sent"

[#177786864]