### PR TITLE
Deprecated in progress

### DIFF
--- a/src/main/java/org/codeforamerica/shiba/ResubmissionService.java
+++ b/src/main/java/org/codeforamerica/shiba/ResubmissionService.java
@@ -167,7 +167,7 @@ public class ResubmissionService {
       MDC.put("applicationId", id);
       log.info("Retriggering submission for application with id " + id);
 
-      documentStatusRepository.createOrUpdateAll(application, SENDING);
+      documentStatusRepository.createOrUpdateApplicationType(application, SENDING);
 
       if (application.getFlow().equals(LATER_DOCS) || !application.getApplicationData()
           .getUploadedDocs().isEmpty()) {

--- a/src/main/java/org/codeforamerica/shiba/ResubmissionService.java
+++ b/src/main/java/org/codeforamerica/shiba/ResubmissionService.java
@@ -3,7 +3,6 @@ package org.codeforamerica.shiba;
 import static org.codeforamerica.shiba.County.Olmsted;
 import static org.codeforamerica.shiba.application.FlowType.LATER_DOCS;
 import static org.codeforamerica.shiba.application.Status.DELIVERED;
-import static org.codeforamerica.shiba.application.Status.IN_PROGRESS;
 import static org.codeforamerica.shiba.application.Status.RESUBMISSION_FAILED;
 import static org.codeforamerica.shiba.application.Status.SENDING;
 import static org.codeforamerica.shiba.application.Status.UNDELIVERABLE;
@@ -119,15 +118,15 @@ public class ResubmissionService {
       initialDelayString = "${in-progress-resubmission.initialDelay.milliseconds:0}"
   )
   @SchedulerLock(name = "esbResubmissionTask", lockAtMostFor = "${in-progress-resubmission.lockAtMostFor}", lockAtLeastFor = "${in-progress-resubmission.lockAtLeastFor}")
-  public void resubmitInProgressAndSendingApplicationsViaEsb() {
+  public void republishApplicationsInSendingStatus() {
     log.info("Checking for applications that are stuck in progress/sending");
 
-    List<Application> applicationsStuckInProgress = applicationRepository.findApplicationsStuckInProgressAndSending();
-    MDC.put("stuckInProgressApps", String.valueOf(applicationsStuckInProgress.size()));
+    List<Application> applicationsStuckSending = applicationRepository.findApplicationsStuckSending();
+    MDC.put("appsStuckSending", String.valueOf(applicationsStuckSending.size()));
     log.info(
-        "Resubmitting " + applicationsStuckInProgress.size() + " applications stuck in progress/sending");
+        "Resubmitting " + applicationsStuckSending.size() + " applications stuck sending");
 
-    for (Application application : applicationsStuckInProgress) {
+    for (Application application : applicationsStuckSending) {
       String id = application.getId();
       // Add applicationId to the logs to make it easier to query for in datadog
       MDC.put("applicationId", id);
@@ -170,7 +169,8 @@ public class ResubmissionService {
 
       documentStatusRepository.createOrUpdateAll(application, SENDING);
 
-      if (application.getFlow().equals(LATER_DOCS) || !application.getApplicationData().getUploadedDocs().isEmpty()) {
+      if (application.getFlow().equals(LATER_DOCS) || !application.getApplicationData()
+          .getUploadedDocs().isEmpty()) {
         documentStatusRepository.createOrUpdateAllForDocumentType(application.getApplicationData(),
             SENDING, UPLOADED_DOC);
       }
@@ -184,10 +184,9 @@ public class ResubmissionService {
 
   private void sendDocumentsViaESB(Application application, String id,
       boolean shouldDeleteDocumentStatuses) {
-    // Resend in progress / sending applications (without verification docs)
-    List<Document> inProgressDocs = application.getDocumentStatuses().stream()
-        .filter(documentStatus -> documentStatus.getStatus().equals(IN_PROGRESS)
-            || documentStatus.getStatus().equals(SENDING) &&
+    // Resend sending applications (without verification docs)
+    List<Document> documentTypesInSending = application.getDocumentStatuses().stream()
+        .filter(documentStatus -> documentStatus.getStatus() == SENDING &&
             List.of(CAF, CCAP, CERTAIN_POPS)
                 .contains(documentStatus.getDocumentType())).map(
             DocumentStatus::getDocumentType
@@ -195,10 +194,10 @@ public class ResubmissionService {
 
     if (shouldDeleteDocumentStatuses) {
       // Will be recreated on submit event
-      documentStatusRepository.delete(id, inProgressDocs);
+      documentStatusRepository.delete(id, documentTypesInSending);
     }
 
-    boolean shouldRefireAppSubmittedEvent = inProgressDocs.stream()
+    boolean shouldRefireAppSubmittedEvent = documentTypesInSending.stream()
         .anyMatch(document -> List.of(CAF, CCAP, CERTAIN_POPS).contains(document));
     if (shouldRefireAppSubmittedEvent) {
       log.info("Retriggering ApplicationSubmittedEvent for application with id " + id);
@@ -207,32 +206,26 @@ public class ResubmissionService {
           application.getApplicationData().getLocale()));
     }
 
-
     // Resend sending verification docs on an application
     Optional<DocumentStatus> uploadedDocStatus = application.getDocumentStatuses().stream()
-        .filter(documentStatus -> documentStatus.getDocumentType() == UPLOADED_DOC && documentStatus.getStatus() == SENDING && application.getFlow() != LATER_DOCS)
-        .findFirst();
-    if (uploadedDocStatus.isPresent()) {
-      resendUploadDocAndUpdateStatus(application, id, shouldDeleteDocumentStatuses);
-    }
-
-    // Resend inprogress / sending verification docs for later docs
-    uploadedDocStatus = application.getDocumentStatuses().stream()
-        .filter(documentStatus -> documentStatus.getDocumentType() == UPLOADED_DOC && List.of(SENDING, IN_PROGRESS).contains(documentStatus.getStatus()) && application.getFlow() == LATER_DOCS)
+        .filter(documentStatus -> documentStatus.getDocumentType() == UPLOADED_DOC
+            && documentStatus.getStatus() == SENDING)
         .findFirst();
     if (uploadedDocStatus.isPresent()) {
       resendUploadDocAndUpdateStatus(application, id, shouldDeleteDocumentStatuses);
     }
   }
 
-  private void resendUploadDocAndUpdateStatus(Application application, String id, boolean shouldDeleteDocumentStatuses) {
+  private void resendUploadDocAndUpdateStatus(Application application, String id,
+      boolean shouldDeleteDocumentStatuses) {
     if (shouldDeleteDocumentStatuses) {
       // Will be recreated on submit event
       documentStatusRepository.delete(id, List.of(UPLOADED_DOC));
     }
-      // No docs to deliver or all files the client uploaded contained 0 bytes of data
+    // No docs to deliver or all files the client uploaded contained 0 bytes of data
     if (application.getApplicationData().getUploadedDocs().isEmpty() ||
-        application.getApplicationData().getUploadedDocs().stream().allMatch(uploadedDocument -> (uploadedDocument.getSize() == 0))) {
+        application.getApplicationData().getUploadedDocs().stream()
+            .allMatch(uploadedDocument -> uploadedDocument.getSize() == 0)) {
       documentStatusRepository.createOrUpdateAllForDocumentType(application.getApplicationData(),
           UNDELIVERABLE, UPLOADED_DOC);
     } else {

--- a/src/main/java/org/codeforamerica/shiba/application/DocumentStatusRepository.java
+++ b/src/main/java/org/codeforamerica/shiba/application/DocumentStatusRepository.java
@@ -37,7 +37,7 @@ public class DocumentStatusRepository {
         new DocumentStatusRowMapper(), applicationId);
   }
 
-  public void createOrUpdateAll(Application application, Status status) {
+  public void createOrUpdateApplicationType(Application application, Status status) {
     List<Document> documents = DocumentListParser.parse(application.getApplicationData());
     handleDocumentDifference(application, documents);
 

--- a/src/main/java/org/codeforamerica/shiba/application/DocumentStatusRepository.java
+++ b/src/main/java/org/codeforamerica/shiba/application/DocumentStatusRepository.java
@@ -37,8 +37,7 @@ public class DocumentStatusRepository {
         new DocumentStatusRowMapper(), applicationId);
   }
 
-  public void createOrUpdateAll(Application application,
-      Status status) {
+  public void createOrUpdateAll(Application application, Status status) {
     List<Document> documents = DocumentListParser.parse(application.getApplicationData());
     handleDocumentDifference(application, documents);
 
@@ -58,14 +57,16 @@ public class DocumentStatusRepository {
     delete(application.getId(), docsToDelete);
   }
 
-  public void createOrUpdateAllForDocumentType(ApplicationData applicationData, Status status, Document document) {
-		List<RoutingDestination> routingDestinations = routingDecisionService.getRoutingDestinations(
-				applicationData, document);
-	      routingDestinations.forEach(
-	          routingDestination -> createOrUpdate(applicationData.getId(), document, routingDestination.getName(),
-	              status));
+  public void createOrUpdateAllForDocumentType(ApplicationData applicationData, Status status,
+      Document document) {
+    List<RoutingDestination> routingDestinations = routingDecisionService.getRoutingDestinations(
+        applicationData, document);
+    routingDestinations.forEach(
+        routingDestination -> createOrUpdate(applicationData.getId(), document,
+            routingDestination.getName(),
+            status));
   }
-  
+
   public void createOrUpdate(String applicationId, Document document, String routingDestinationName,
       Status status) {
     if (document == null || routingDestinationName == null) {
@@ -101,12 +102,12 @@ public class DocumentStatusRepository {
 
   }
 
-  public void delete(String applicationId, List <Document> documents){
+  public void delete(String applicationId, List<Document> documents) {
     if (!documents.isEmpty()) {
       String deleteStatement = """
-        DELETE FROM application_status WHERE application_id = :application_id
-        AND document_type in (:document_types)
-        """;
+          DELETE FROM application_status WHERE application_id = :application_id
+          AND document_type in (:document_types)
+          """;
       Map<String, Object> parameters = new HashMap<>();
       parameters.put("application_id", applicationId);
       parameters.put("document_types", documents.stream().map(Enum::toString).toList());
@@ -136,6 +137,7 @@ public class DocumentStatusRepository {
   }
 
   private static class DocumentStatusRowMapper implements RowMapper<DocumentStatus> {
+
     @Override
     public DocumentStatus mapRow(ResultSet rs, int rowNum) throws SQLException {
       return new DocumentStatus(

--- a/src/main/java/org/codeforamerica/shiba/application/Status.java
+++ b/src/main/java/org/codeforamerica/shiba/application/Status.java
@@ -1,7 +1,6 @@
 package org.codeforamerica.shiba.application;
 
 public enum Status {
-  IN_PROGRESS("in_progress"),
   SENDING("sending"),
   DELIVERED("delivered"),
   DELIVERY_FAILED("delivery_failed"),
@@ -16,7 +15,6 @@ public enum Status {
 
   public static Status valueFor(String displayName) {
     return switch (displayName) {
-      case "in_progress" -> IN_PROGRESS;
       case "sending" -> SENDING;
       case "delivered" -> DELIVERED;
       case "delivery_failed" -> DELIVERY_FAILED;

--- a/src/main/java/org/codeforamerica/shiba/pages/PageController.java
+++ b/src/main/java/org/codeforamerica/shiba/pages/PageController.java
@@ -338,7 +338,7 @@ public class PageController {
 
   private boolean missingRequiredSubworkflows(PageWorkflowConfiguration pageWorkflow) {
     return pageWorkflow.getPageConfiguration().getInputs().isEmpty() &&
-           !applicationData.hasRequiredSubworkflows(pageWorkflow.getDatasources());
+        !applicationData.hasRequiredSubworkflows(pageWorkflow.getDatasources());
   }
 
   private boolean isStartPageForGroup(@PathVariable String pageName, String groupName) {
@@ -368,9 +368,9 @@ public class PageController {
     List<Eligibility> expeditedEligibilityList = new ArrayList<Eligibility>();
     expeditedEligibilityList.add(snapExpeditedEligibility);
     expeditedEligibilityList.add(ccapExpeditedEligibility);
-	List<ExpeditedEligibility> list = listBuilder.buildEligibilityList(expeditedEligibilityList);
-	applicationData.setExpeditedEligibility(list);
-    
+    List<ExpeditedEligibility> list = listBuilder.buildEligibilityList(expeditedEligibilityList);
+    applicationData.setExpeditedEligibility(list);
+
     if (pageWorkflow.getPageConfiguration().isStaticPage()) {
       model.put("pageNameContext", pageName);
     }
@@ -472,7 +472,7 @@ public class PageController {
         .getLandmarkPages();
     // If they requested landing page or application is unstarted
     boolean unstarted = !landmarkPagesConfiguration.isLandingPage(pageName)
-                        && applicationData.getStartTime() == null;
+        && applicationData.getStartTime() == null;
     // If they are restarting the application process after submitting
     boolean restarted =
         applicationData.isSubmitted() && landmarkPagesConfiguration.isStartTimerPage(pageName);
@@ -484,9 +484,9 @@ public class PageController {
         .getLandmarkPages();
     // Application is already submitted and not at the beginning of the application process
     return !landmarkPagesConfiguration.isPostSubmitPage(pageName) &&
-           !landmarkPagesConfiguration.isLandingPage(pageName) &&
-           !landmarkPagesConfiguration.isStartTimerPage(pageName) &&
-           applicationData.isSubmitted();
+        !landmarkPagesConfiguration.isLandingPage(pageName) &&
+        !landmarkPagesConfiguration.isStartTimerPage(pageName) &&
+        applicationData.isSubmitted();
   }
 
   private boolean shouldRedirectToNextStepsPage(String pageName) {
@@ -600,9 +600,9 @@ public class PageController {
       if (applicationData.getId() == null) {
         applicationData.setId(applicationRepository.getNextId());
       }
-      
+
       if (pageName != null || !pageName.isEmpty()) {
-          applicationData.setLastPageViewed(pageName);
+        applicationData.setLastPageViewed(pageName);
       }
 
       ofNullable(pageWorkflow.getEnrichment())
@@ -641,8 +641,9 @@ public class PageController {
       }
       Application application = applicationFactory.newApplication(applicationData);
       application.setCompletedAtTime(clock); // how we mark that the application is complete
-      recordDeviceType(device,application);
+      recordDeviceType(device, application);
       applicationRepository.save(application);
+      documentStatusRepository.createOrUpdateApplicationType(application, SENDING);
       log.info("Invoking pageEventPublisher for application submission: " + application.getId());
       pageEventPublisher.publish(
           new ApplicationSubmittedEvent(httpSession.getId(), application.getId(),
@@ -656,23 +657,23 @@ public class PageController {
   }
 
   private void recordDeviceType(Device device, Application application) {
-      String deviceType = "unknown";
-      String platform = "unknown";
-      if(device != null) {
-	      if (device.isNormal()) {
-	          deviceType = "desktop";
-	      } else if (device.isMobile()) {
-	          deviceType = "mobile";
-	      } else if (device.isTablet()) {
-	          deviceType = "tablet";
-	      }
-	      platform = device.getDevicePlatform().name();
+    String deviceType = "unknown";
+    String platform = "unknown";
+    if (device != null) {
+      if (device.isNormal()) {
+        deviceType = "desktop";
+      } else if (device.isMobile()) {
+        deviceType = "mobile";
+      } else if (device.isTablet()) {
+        deviceType = "tablet";
       }
-      application.getApplicationData().setDevicePlatform(platform);
-      application.getApplicationData().setDeviceType(deviceType);
+      platform = device.getDevicePlatform().name();
+    }
+    application.getApplicationData().setDevicePlatform(platform);
+    application.getApplicationData().setDeviceType(deviceType);
   }
 
-@PostMapping("/submit-feedback")
+  @PostMapping("/submit-feedback")
   RedirectView submitFeedback(Feedback feedback,
       RedirectAttributes redirectAttributes,
       Locale locale) {

--- a/src/main/java/org/codeforamerica/shiba/pages/config/LandmarkPagesConfiguration.java
+++ b/src/main/java/org/codeforamerica/shiba/pages/config/LandmarkPagesConfiguration.java
@@ -8,7 +8,6 @@ import lombok.Data;
 public class LandmarkPagesConfiguration {
 
   private List<String> startTimerPages = new ArrayList<>();
-  private List<String> inProgressStatusPages = new ArrayList<>();
   private List<String> landingPages = new ArrayList<>();
   private List<String> postSubmitPages = new ArrayList<>();
   private String nextStepsPage;
@@ -54,7 +53,4 @@ public class LandmarkPagesConfiguration {
     return pageName.equals(nextStepsPage);
   }
 
-  public boolean isInProgressStatusPage(String pageName) {
-    return inProgressStatusPages.contains(pageName);
-  }
 }

--- a/src/main/resources/pages-config.yaml
+++ b/src/main/resources/pages-config.yaml
@@ -4300,9 +4300,6 @@ landmarkPages:
   startTimerPages: # "the first page" of a flow, where we set applicationData.startTime
     - identifyCountyBeforeApplying
     - identifyCounty
-  inProgressStatusPages: # Set application status to "in_progress"
-    - choosePrograms
-    - identifyCounty
   landingPages: # the home page of the app
     - landing
   postSubmitPages: # pages which are accessible after submitting an application, also all pages of the laterdocs flow

--- a/src/test/java/org/codeforamerica/shiba/AppsStuckSendingResubmissionTest.java
+++ b/src/test/java/org/codeforamerica/shiba/AppsStuckSendingResubmissionTest.java
@@ -1,5 +1,6 @@
 package org.codeforamerica.shiba;
 
+import static java.time.ZonedDateTime.now;
 import static org.codeforamerica.shiba.County.Anoka;
 import static org.codeforamerica.shiba.Program.CASH;
 import static org.codeforamerica.shiba.Program.SNAP;
@@ -9,14 +10,12 @@ import static org.codeforamerica.shiba.output.Document.UPLOADED_DOC;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
-import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
 import org.codeforamerica.shiba.application.Application;
 import org.codeforamerica.shiba.application.ApplicationRepository;
 import org.codeforamerica.shiba.application.DocumentStatusRepository;
 import org.codeforamerica.shiba.application.FlowType;
-import org.codeforamerica.shiba.application.Status;
 import org.codeforamerica.shiba.output.Document;
 import org.codeforamerica.shiba.pages.data.ApplicationData;
 import org.codeforamerica.shiba.pages.events.ApplicationSubmittedEvent;
@@ -37,7 +36,7 @@ import org.springframework.test.context.jdbc.Sql;
 @ActiveProfiles("test")
 // drop all applications and application statuses before this test runs to avoid test pollution
 @Sql(statements = {"TRUNCATE TABLE applications", "TRUNCATE TABLE application_status"})
-class AppsStuckInProgressResubmissionTest {
+class AppsStuckSendingResubmissionTest {
 
   @Autowired
   private ResubmissionService resubmissionService;
@@ -52,14 +51,14 @@ class AppsStuckInProgressResubmissionTest {
   private PageEventPublisher pageEventPublisher;
 
   @Test
-  void itTriggersAnEventFor50AppsStuckInProgress() {
+  void itTriggersAnEventFor50AppsStuckSending() {
     // Only the first 50 of these should be resubmitted.
     for (int i = 0; i < 51; i++) {
-      makeApplicationThatShouldBeResubmitted(i, Status.IN_PROGRESS);
+      makeApplicationThatShouldBeResubmitted(i);
     }
 
     // actually try to resubmit it
-    resubmissionService.resubmitInProgressAndSendingApplicationsViaEsb();
+    resubmissionService.republishApplicationsInSendingStatus();
 
     // make sure that the first 50 applications had an applicationSubmittedEvent triggered
     for (int i = 0; i < 50; i++) {
@@ -81,34 +80,13 @@ class AppsStuckInProgressResubmissionTest {
   }
 
   @Test
-  void itTriggersAnEventFor50AppsStuckSending() {
-    // Only the first 50 of these should be resubmitted.
-    for (int i = 60; i < 111; i++) {
-      makeApplicationThatShouldBeResubmitted(i, SENDING);
-    }
-
-    // actually try to resubmit it
-    resubmissionService.resubmitInProgressAndSendingApplicationsViaEsb();
-
-    // make sure that the first 50 applications had an applicationSubmittedEvent triggered
-    for (int i = 60; i < 110; i++) {
-      verify(pageEventPublisher).publish(
-          new ApplicationSubmittedEvent("resubmission", String.valueOf(i), FlowType.FULL,
-              LocaleContextHolder.getLocale()));
-      verify(pageEventPublisher).publish(
-          new UploadedDocumentsSubmittedEvent("resubmission", String.valueOf(i),
-              LocaleContextHolder.getLocale()));
-    }
-  }
-  
-  @Test
   void itDoesNotTriggerAnEventForAppsThatShouldNotBeResubmitted() {
-    String applicationIdToResubmit = makeApplicationThatShouldBeResubmitted(1, Status.IN_PROGRESS);
-    String applicationIdThatShouldNotBeResubmitted = makeInProgressApplicationThatShouldNotBeResubmitted();
-    String applicationIdThatIsNotInProgress = makeApplicationThatWasDelivered();
+    String applicationIdToResubmit = makeApplicationThatShouldBeResubmitted(1);
+    String applicationIdThatShouldNotBeResubmitted = makeSendingApplicationThatShouldNotBeResubmitted();
+    String applicationIdThatWasDelivered = makeApplicationThatWasDelivered();
 
     // actually try to resubmit it
-    resubmissionService.resubmitInProgressAndSendingApplicationsViaEsb();
+    resubmissionService.republishApplicationsInSendingStatus();
 
     verify(pageEventPublisher).publish(
         new ApplicationSubmittedEvent("resubmission", applicationIdToResubmit, FlowType.FULL,
@@ -126,16 +104,16 @@ class AppsStuckInProgressResubmissionTest {
             LocaleContextHolder.getLocale()));
 
     verify(pageEventPublisher, never()).publish(
-        new ApplicationSubmittedEvent("resubmission", applicationIdThatIsNotInProgress,
+        new ApplicationSubmittedEvent("resubmission", applicationIdThatWasDelivered,
             FlowType.FULL,
             LocaleContextHolder.getLocale()));
     verify(pageEventPublisher, never()).publish(
-        new UploadedDocumentsSubmittedEvent("resubmission", applicationIdThatIsNotInProgress,
+        new UploadedDocumentsSubmittedEvent("resubmission", applicationIdThatWasDelivered,
             LocaleContextHolder.getLocale()));
   }
 
   @NotNull
-  private String makeApplicationThatShouldBeResubmitted(int id, Status status) {
+  private String makeApplicationThatShouldBeResubmitted(int id) {
     String applicationId = String.valueOf(id);
 
     ApplicationData applicationData = new TestApplicationDataBuilder().withUploadedDocs();
@@ -147,22 +125,22 @@ class AppsStuckInProgressResubmissionTest {
         .withPageData("choosePrograms", "programs", List.of(SNAP, CASH))
         .build());
 
-    Application inProgressApplicationThatShouldBeCompleted = Application.builder()
-        .completedAt(ZonedDateTime.now().minusHours(10)) // important that this is completed!!!
+    Application applicationStuckSending = Application.builder()
+        .completedAt(now().minusHours(10)) // outside of 8hr window and should be resubmitted
         .county(Anoka)
         .id(applicationId)
         .applicationData(applicationData)
         .docUploadEmailStatus(null)
         .flow(FlowType.FULL)
         .build();
-    applicationRepository.save(inProgressApplicationThatShouldBeCompleted);
+    applicationRepository.save(applicationStuckSending);
 
     // Save CAF
     documentStatusRepository.createOrUpdate(
         applicationId,
         Document.CAF,
         "Anoka",
-        status);
+        SENDING);
 
     documentStatusRepository.createOrUpdate(
         applicationId,
@@ -174,7 +152,7 @@ class AppsStuckInProgressResubmissionTest {
   }
 
   @NotNull
-  private String makeInProgressApplicationThatShouldNotBeResubmitted() {
+  private String makeSendingApplicationThatShouldNotBeResubmitted() {
     ApplicationData applicationData = new ApplicationData();
     applicationData.setPagesData(new PagesDataBuilder()
         .withPageData("contactInfo", Map.of(
@@ -184,21 +162,21 @@ class AppsStuckInProgressResubmissionTest {
         .withPageData("choosePrograms", "programs", List.of(SNAP, CASH))
         .build());
     String applicationId = "6";
-    Application inProgressApplicationThatShouldBeCompleted = Application.builder()
-        .completedAt(ZonedDateTime.now().minusHours(1)) // important that this is completed!!!
+    Application sendingApplicationThatShouldBeCompleted = Application.builder()
+        .completedAt(now().minusHours(1)) // within 8hr window of apps that might be retrying
         .county(Anoka)
         .id(applicationId)
         .applicationData(applicationData)
         .docUploadEmailStatus(null)
         .flow(FlowType.FULL)
         .build();
-    applicationRepository.save(inProgressApplicationThatShouldBeCompleted);
+    applicationRepository.save(sendingApplicationThatShouldBeCompleted);
 
     documentStatusRepository.createOrUpdate(
         applicationId,
         Document.CAF,
         "Anoka",
-        Status.IN_PROGRESS);
+        SENDING);
     return applicationId;
   }
 
@@ -213,15 +191,15 @@ class AppsStuckInProgressResubmissionTest {
         .withPageData("choosePrograms", "programs", List.of(SNAP, CASH))
         .build());
     String applicationId = "7";
-    Application inProgressApplicationThatShouldBeCompleted = Application.builder()
-        .completedAt(ZonedDateTime.now().minusHours(12)) // important that this is completed!!!
+    Application sendingApplicationThatShouldBeCompleted = Application.builder()
+        .completedAt(now().minusHours(12)) // outside of 8hr window of apps that are retrying
         .county(Anoka)
         .id(applicationId)
         .applicationData(applicationData)
         .docUploadEmailStatus(null)
         .flow(FlowType.FULL)
         .build();
-    applicationRepository.save(inProgressApplicationThatShouldBeCompleted);
+    applicationRepository.save(sendingApplicationThatShouldBeCompleted);
 
     documentStatusRepository.createOrUpdate(
         applicationId,

--- a/src/test/java/org/codeforamerica/shiba/application/DocumentStatusRepositoryTest.java
+++ b/src/test/java/org/codeforamerica/shiba/application/DocumentStatusRepositoryTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.codeforamerica.shiba.County.Olmsted;
 import static org.codeforamerica.shiba.application.Status.DELIVERED;
 import static org.codeforamerica.shiba.application.Status.DELIVERY_FAILED;
-import static org.codeforamerica.shiba.application.Status.IN_PROGRESS;
 import static org.codeforamerica.shiba.application.Status.SENDING;
 import static org.codeforamerica.shiba.output.Document.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -70,23 +69,23 @@ public class DocumentStatusRepositoryTest extends AbstractRepositoryTest {
         .county(Olmsted)
         .build();
 
-    documentStatusRepository.createOrUpdateAll(application, IN_PROGRESS);
+    documentStatusRepository.createOrUpdateAll(application, SENDING);
     List<DocumentStatus> resultingStatuses = documentStatusRepository.findAll(
         applicationData.getId());
     assertThat(resultingStatuses).containsExactlyInAnyOrder(
         new DocumentStatus(applicationData.getId(), CAF, routingDestination.getName(),
-            IN_PROGRESS),
+            SENDING),
         new DocumentStatus(applicationData.getId(), CERTAIN_POPS, routingDestination.getName(),
-            IN_PROGRESS)
+            SENDING)
     );
 
     new TestApplicationDataBuilder(applicationData)
         .withApplicantPrograms(List.of("CCAP"));
-    documentStatusRepository.createOrUpdateAll(application, IN_PROGRESS);
+    documentStatusRepository.createOrUpdateAll(application, SENDING);
     resultingStatuses = documentStatusRepository.findAll(applicationData.getId());
     assertThat(resultingStatuses).containsExactlyInAnyOrder(
         new DocumentStatus(applicationData.getId(), CCAP, routingDestination.getName(),
-            IN_PROGRESS)
+            SENDING)
     );
   }
 
@@ -98,8 +97,8 @@ public class DocumentStatusRepositoryTest extends AbstractRepositoryTest {
     documentStatusRepository.createOrUpdate("someId2", UPLOADED_DOC, "Olmsted", DELIVERY_FAILED);
     documentStatusRepository.createOrUpdate("someId2", CERTAIN_POPS, "Olmsted", SENDING);
 
-    documentStatusRepository.createOrUpdate("someId3", CAF, "Olmsted", IN_PROGRESS);
-    documentStatusRepository.createOrUpdate("someId3", UPLOADED_DOC, "Olmsted", IN_PROGRESS);
+    documentStatusRepository.createOrUpdate("someId3", CAF, "Olmsted", SENDING);
+    documentStatusRepository.createOrUpdate("someId3", UPLOADED_DOC, "Olmsted", SENDING);
 
     documentStatusRepository.createOrUpdate("someId4", CCAP, "Olmsted", DELIVERY_FAILED);
 
@@ -123,14 +122,14 @@ public class DocumentStatusRepositoryTest extends AbstractRepositoryTest {
         .applicationData(applicationData)
         .county(Olmsted)
         .build();
-    documentStatusRepository.createOrUpdateAll(application, IN_PROGRESS);
+    documentStatusRepository.createOrUpdateAll(application, SENDING);
     List<DocumentStatus> resultingStatuses = documentStatusRepository.findAll(
         applicationData.getId());
     assertThat(resultingStatuses).containsExactlyInAnyOrder(
         new DocumentStatus(applicationData.getId(), CAF, routingDestination.getName(),
-            IN_PROGRESS),
+            SENDING),
         new DocumentStatus(applicationData.getId(), CERTAIN_POPS, routingDestination.getName(),
-            IN_PROGRESS)
+            SENDING)
     );
 
     ApplicationData applicationData2 = new TestApplicationDataBuilder()
@@ -139,14 +138,14 @@ public class DocumentStatusRepositoryTest extends AbstractRepositoryTest {
         .build();
 
     application.setApplicationData(applicationData2);
-    documentStatusRepository.createOrUpdateAll(application, IN_PROGRESS);
+    documentStatusRepository.createOrUpdateAll(application, SENDING);
     List<DocumentStatus> resultingStatuses2 = documentStatusRepository.findAll(
         applicationData.getId());
     assertThat(resultingStatuses2).containsExactlyInAnyOrder(
         new DocumentStatus(applicationData.getId(), CAF, routingDestination.getName(),
-            IN_PROGRESS),
+            SENDING),
         new DocumentStatus(applicationData.getId(), CCAP, routingDestination.getName(),
-            IN_PROGRESS)
+            SENDING)
     );
   }
 }

--- a/src/test/java/org/codeforamerica/shiba/application/DocumentStatusRepositoryTest.java
+++ b/src/test/java/org/codeforamerica/shiba/application/DocumentStatusRepositoryTest.java
@@ -69,7 +69,7 @@ public class DocumentStatusRepositoryTest extends AbstractRepositoryTest {
         .county(Olmsted)
         .build();
 
-    documentStatusRepository.createOrUpdateAll(application, SENDING);
+    documentStatusRepository.createOrUpdateApplicationType(application, SENDING);
     List<DocumentStatus> resultingStatuses = documentStatusRepository.findAll(
         applicationData.getId());
     assertThat(resultingStatuses).containsExactlyInAnyOrder(
@@ -81,7 +81,7 @@ public class DocumentStatusRepositoryTest extends AbstractRepositoryTest {
 
     new TestApplicationDataBuilder(applicationData)
         .withApplicantPrograms(List.of("CCAP"));
-    documentStatusRepository.createOrUpdateAll(application, SENDING);
+    documentStatusRepository.createOrUpdateApplicationType(application, SENDING);
     resultingStatuses = documentStatusRepository.findAll(applicationData.getId());
     assertThat(resultingStatuses).containsExactlyInAnyOrder(
         new DocumentStatus(applicationData.getId(), CCAP, routingDestination.getName(),
@@ -122,7 +122,7 @@ public class DocumentStatusRepositoryTest extends AbstractRepositoryTest {
         .applicationData(applicationData)
         .county(Olmsted)
         .build();
-    documentStatusRepository.createOrUpdateAll(application, SENDING);
+    documentStatusRepository.createOrUpdateApplicationType(application, SENDING);
     List<DocumentStatus> resultingStatuses = documentStatusRepository.findAll(
         applicationData.getId());
     assertThat(resultingStatuses).containsExactlyInAnyOrder(
@@ -138,7 +138,7 @@ public class DocumentStatusRepositoryTest extends AbstractRepositoryTest {
         .build();
 
     application.setApplicationData(applicationData2);
-    documentStatusRepository.createOrUpdateAll(application, SENDING);
+    documentStatusRepository.createOrUpdateApplicationType(application, SENDING);
     List<DocumentStatus> resultingStatuses2 = documentStatusRepository.findAll(
         applicationData.getId());
     assertThat(resultingStatuses2).containsExactlyInAnyOrder(

--- a/src/test/resources/pages-config/test-pages-controller.yaml
+++ b/src/test/resources/pages-config/test-pages-controller.yaml
@@ -49,8 +49,6 @@ landmarkPages:
     - landingPage
   startTimerPages:
     - firstPage
-  inProgressStatusPages:
-    - firstPage
   terminalPage: terminalPage
   submitPage: secondPage
   uploadDocumentsPage: uploadDocuments


### PR DESCRIPTION
Deprecating IN_PROGRESS status. This is no longer needed. 
- We now expect only to see applications stuck in "sending" status if events are dropped/interrupted.
- Leaving in resubmission logic to find blank statuses for now, we dont expect to see these anymore
- Fixes issue with applications that only need to be sent to tribal nations getting sent twice because of unintentional in_progress status for county triggering resubmission